### PR TITLE
Add Travis CI file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: c
+
+compiler:
+  - clang
+  - gcc
+
+install:
+ - wget https://raw.githubusercontent.com/torvalds/linux/master/scripts/checkpatch.pl
+ - wget https://raw.githubusercontent.com/torvalds/linux/master/scripts/spelling.txt
+ - wget https://raw.githubusercontent.com/torvalds/linux/master/scripts/const_structs.checkpatch
+
+script:
+ - make check
+ - perl checkpatch.pl --no-tree -f --strict --show-types --ignore NEW_TYPEDEFS --ignore PREFER_KERNEL_TYPES --ignore SPLIT_STRING *.c *.h

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Subtilis
 
+[![Build Status](https://travis-ci.org/markdryan/subtilis.svg?branch=master)](https://travis-ci.org/markdryan/subtilis)
+
+
 A BASIC (BBC) compiler for retro computers.  (At least that's the plan.  Right now
 there's nothing but a half complete lexical analyser.)
 


### PR DESCRIPTION
Adds a travis CI file to enable CI on all PRs.  The .travis.yml file
currently runs unit tests and checkpatch.pl.