### PR TITLE
Improve max token size handling

### DIFF
--- a/buffer.c
+++ b/buffer.c
@@ -181,6 +181,17 @@ void subtilis_buffer_zero_terminate(subtilis_buffer_t *buffer,
 		subtilis_buffer_append(buffer, &zero, 1, err);
 }
 
+void subtilis_buffer_remove_terminator(subtilis_buffer_t *buffer)
+{
+	subtilis_fixed_buffer_t *b = buffer->buffer;
+
+	if (!b)
+		return;
+
+	while ((b->end > b->start) && (((char *)b->data)[b->end - 1] == 0))
+		b->end--;
+}
+
 void subtilis_buffer_free(subtilis_buffer_t *buffer)
 {
 	if (!buffer->buffer)

--- a/buffer.h
+++ b/buffer.h
@@ -55,6 +55,7 @@ void subtilis_buffer_delete(subtilis_buffer_t *buffer, size_t pos,
 			    size_t length, subtilis_error_t *err);
 void subtilis_buffer_zero_terminate(subtilis_buffer_t *buffer,
 				    subtilis_error_t *err);
+void subtilis_buffer_remove_terminator(subtilis_buffer_t *buffer);
 void subtilis_buffer_free(subtilis_buffer_t *buffer);
 void subtilis_buffer_reset(subtilis_buffer_t *buffer);
 size_t subtilis_buffer_get_size(const subtilis_buffer_t *buffer);

--- a/compiler.c
+++ b/compiler.c
@@ -24,7 +24,7 @@ int main(int argc, char *argv[])
 	subtilis_error_t err;
 	subtilis_stream_t s;
 	subtilis_lexer_t *l = NULL;
-	subtilis_token_t t;
+	subtilis_token_t *t = NULL;
 
 	if (argc != 2) {
 		fprintf(stderr, "Usage: basicc file\n");
@@ -39,18 +39,24 @@ int main(int argc, char *argv[])
 	if (err.type != SUBTILIS_ERROR_OK)
 		goto cleanup;
 
+	t = subtilis_token_new(&err);
+	if (err.type != SUBTILIS_ERROR_OK)
+		goto cleanup;
+
 	do {
-		subtilis_lexer_get(l, &t, &err);
+		subtilis_lexer_get(l, t, &err);
 		if (err.type != SUBTILIS_ERROR_OK)
 			goto cleanup;
-		subtilis_dump_token(&t);
-	} while (t.type != SUBTILIS_TOKEN_EOF);
+		subtilis_dump_token(t);
+	} while (t->type != SUBTILIS_TOKEN_EOF);
 
+	subtilis_token_delete(t);
 	subtilis_lexer_delete(l, &err);
 
 	return 0;
 
 cleanup:
+	subtilis_token_delete(t);
 	if (l)
 		subtilis_lexer_delete(l, &err);
 	else

--- a/lexer.c
+++ b/lexer.c
@@ -22,16 +22,6 @@
 
 #include "lexer.h"
 
-/* TODO token too long
- *
--*  We probably do want to set a limit which we can make configurable
- *  even if we use buffers.
--* or maybe not.  If we do set a limit we will need to skip the rest of the
- * token.
- *
- * - I'm now think the code will be simpler if we don't set any limit
- */
-
 typedef enum {
 	SUBTILIS_TOKEN_END_TOKEN,
 	SUBTILIS_TOKEN_END_NOT_TOKEN,
@@ -71,27 +61,53 @@ void subtilis_lexer_delete(subtilis_lexer_t *l, subtilis_error_t *err)
 	}
 }
 
-static void prv_set_first(subtilis_lexer_t *l, subtilis_token_t *t, char ch,
+/* subtilis_token_new will reserve SUBTILIS_MAX_TOKEN_SIZE + 1 in bytes for the
+ * token's buffer.  All tokens apart from strings must be less than or equal to
+ * SUBTILIS_MAX_TOKEN_SIZE in size so we don't need to check for errors
+ * when appending to the token buffer.  In most cases we can use
+ * prv_set_first and prv_set_next but when processing strings we'll need to use
+ * prv_set_next_with_err.
+ */
+
+static void prv_set_next_with_err(subtilis_lexer_t *l, subtilis_token_t *t,
+				  subtilis_error_t *err)
+{
+	char ch = l->buffer[l->index];
+
+	subtilis_buffer_append(&t->buf, &ch, 1, err);
+	if (err->type == SUBTILIS_ERROR_OK)
+		l->index++;
+}
+
+static void prv_set_next(subtilis_lexer_t *l, subtilis_token_t *t)
+{
+	subtilis_error_t err;
+
+	subtilis_error_init(&err);
+	prv_set_next_with_err(l, t, &err);
+}
+
+static void prv_set_first(subtilis_lexer_t *l, subtilis_token_t *t,
 			  subtilis_token_type_t type)
 {
 	t->type = type;
-	t->buf[0] = ch;
-	t->buf[1] = 0;
-	l->index++;
-	t->token_size = 1;
+	prv_set_next(l, t);
 }
 
-static void prv_set_next(subtilis_lexer_t *l, subtilis_token_t *t, char ch,
-			 int index)
+const char *subtilis_token_get_text(subtilis_token_t *t)
 {
-	l->index++;
-	t->buf[index] = ch;
-	t->token_size++;
-	t->buf[index + 1] = 0;
+	const char *tbuf;
+	subtilis_error_t err;
+
+	subtilis_error_init(&err);
+	subtilis_buffer_zero_terminate(&t->buf, &err);
+	if (err.type == SUBTILIS_ERROR_OK)
+		tbuf = subtilis_buffer_get_string(&t->buf);
+	else
+		tbuf = "<TOKEN TEXT UNAVAILABLE>";
+	return tbuf;
 }
 
-// TODO: We can make these two return the errors which should remove a
-// line of code for the callers.
 static void prv_ensure_buffer(subtilis_lexer_t *l, subtilis_error_t *err)
 {
 	if (l->index < l->buf_end)
@@ -102,8 +118,6 @@ static void prv_ensure_buffer(subtilis_lexer_t *l, subtilis_error_t *err)
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
 
-	/* TODO:  This is wrong.  We should set this to 0 before we return */
-
 	l->index = 0;
 }
 
@@ -111,10 +125,13 @@ static void prv_ensure_token_buffer(subtilis_lexer_t *l, subtilis_token_t *t,
 				    subtilis_error_t *err,
 				    subtilis_error_type_t type)
 {
-	if (t->token_size < SUBTILIS_MAX_TOKEN_SIZE)
+	const char *tbuf;
+
+	if (subtilis_buffer_get_size(&t->buf) < SUBTILIS_MAX_TOKEN_SIZE)
 		return;
-	t->buf[SUBTILIS_MAX_TOKEN_SIZE] = 0;
-	subtilis_error_set1(err, type, t->buf, l->stream->name, l->line);
+
+	tbuf = subtilis_token_get_text(t);
+	subtilis_error_set1(err, type, tbuf, l->stream->name, l->line);
 }
 
 static bool prv_is_whitespace(char c)
@@ -135,49 +152,49 @@ static bool prv_is_separator(char c)
 	return prv_is_whitespace(c) || prv_is_simple_operator(c);
 }
 
-static void prv_process_complex_operator(subtilis_lexer_t *l, char ch,
+static void prv_process_complex_operator(subtilis_lexer_t *l,
 					 subtilis_token_t *t,
 					 subtilis_error_t *err)
 {
+	char ch;
 	char ch1;
 
-	prv_set_first(l, t, ch, SUBTILIS_TOKEN_OPERATOR);
+	ch = l->buffer[l->index];
+
+	prv_set_first(l, t, SUBTILIS_TOKEN_OPERATOR);
 	prv_ensure_buffer(l, err);
-	if (err->type != SUBTILIS_ERROR_OK)
-		return;
-	if (l->index == l->buf_end)
+	if ((err->type != SUBTILIS_ERROR_OK) || (l->index == l->buf_end))
 		return;
 
 	ch1 = l->buffer[l->index];
 	switch (ch1) {
 	case '=':
-		prv_set_next(l, t, ch1, 1);
+		prv_set_next(l, t);
 		break;
 	case '<':
 		if (ch == '<')
-			prv_set_next(l, t, ch1, 1);
+			prv_set_next(l, t);
 		break;
 	case '>':
 		if (ch == '<') {
-			prv_set_next(l, t, ch1, 1);
+			prv_set_next(l, t);
 			break;
 		}
 
 		if (ch != '>')
 			return;
-		prv_set_next(l, t, ch1, 1);
+		prv_set_next(l, t);
 
 		prv_ensure_buffer(l, err);
-		if (err->type != SUBTILIS_ERROR_OK)
-			return;
-		if (l->index == l->buf_end)
-			return;
+		if ((err->type != SUBTILIS_ERROR_OK) ||
+		    (l->index == l->buf_end))
+			break;
 
 		ch1 = l->buffer[l->index];
 		if (ch1 != '>')
-			return;
+			break;
 
-		prv_set_next(l, t, ch1, 2);
+		prv_set_next(l, t);
 		break;
 	default:
 		break;
@@ -187,32 +204,34 @@ static void prv_process_complex_operator(subtilis_lexer_t *l, char ch,
 static bool prv_extract_number(subtilis_lexer_t *l, subtilis_token_t *t,
 			       token_end_t end_fn, subtilis_error_t *err)
 {
-	char ch;
 	subtilis_token_end_t end;
+	bool processed = false;
 
-	while (t->token_size < SUBTILIS_MAX_TOKEN_SIZE) {
+	for (;;) {
 		prv_ensure_buffer(l, err);
 		if (err->type != SUBTILIS_ERROR_OK)
-			return false;
-		if (l->index == l->buf_end)
-			return true;
-		ch = l->buffer[l->index];
-		end = end_fn(l, t, ch, err);
-		if (end == SUBTILIS_TOKEN_END_RETURN)
-			return false;
-		else if (end == SUBTILIS_TOKEN_END_NOT_TOKEN)
-			return true;
-		t->buf[t->token_size++] = ch;
-		l->index++;
+			break;
+		if (l->index == l->buf_end) {
+			processed = true;
+			break;
+		}
+		end = end_fn(l, t, l->buffer[l->index], err);
+		if (end == SUBTILIS_TOKEN_END_RETURN) {
+			break;
+		} else if (end == SUBTILIS_TOKEN_END_NOT_TOKEN) {
+			processed = true;
+			break;
+		}
+
+		prv_ensure_token_buffer(l, t, err,
+					SUBTILIS_ERROR_NUMBER_TOO_LONG);
+		if (err->type != SUBTILIS_ERROR_OK)
+			break;
+
+		prv_set_next(l, t);
 	}
 
-	if (t->token_size == 255) {
-		t->buf[t->token_size] = 0;
-		subtilis_error_set_number_too_long(err, t->buf, l->stream->name,
-						   l->line);
-	}
-
-	return true;
+	return processed;
 }
 
 static subtilis_token_end_t prv_float_end(subtilis_lexer_t *l,
@@ -228,14 +247,11 @@ static subtilis_token_end_t prv_float_end(subtilis_lexer_t *l,
 static void prv_process_float(subtilis_lexer_t *l, subtilis_token_t *t,
 			      subtilis_error_t *err)
 {
-	t->type = SUBTILIS_TOKEN_REAL;
-	t->buf[t->token_size++] = '.';
-	l->index++;
+	prv_set_first(l, t, SUBTILIS_TOKEN_REAL);
 	if (!prv_extract_number(l, t, prv_float_end, err))
 		return;
 
-	t->buf[t->token_size] = 0;
-	t->tok.real = atof(t->buf);
+	t->tok.real = atof(subtilis_token_get_text(t));
 }
 
 /* TODO:  Need to figure out if maximum negative int constant is correct */
@@ -245,18 +261,19 @@ static void prv_parse_integer(subtilis_lexer_t *l, subtilis_token_t *t,
 {
 	char *end_ptr = 0;
 	unsigned long num;
+	const char *tbuf = subtilis_token_get_text(t);
 
-	t->buf[t->token_size] = 0;
 	errno = 0;
-	num = strtoul(t->buf, &end_ptr, base);
+	num = strtoul(tbuf, &end_ptr, base);
 	if (*end_ptr != 0 || errno != 0 || num > 2147483647) {
-		subtilis_error_set_number_too_long(err, t->buf, l->stream->name,
+		subtilis_error_set_number_too_long(err, tbuf, l->stream->name,
 						   l->line);
 		return;
 	}
 	t->tok.integer = (int32_t)num;
 }
 
+/* TODO: This is a bit nasty.  Is there a nicer way? */
 static subtilis_token_end_t prv_decimal_end(subtilis_lexer_t *l,
 					    subtilis_token_t *t, char ch,
 					    subtilis_error_t *err)
@@ -274,7 +291,7 @@ static subtilis_token_end_t prv_decimal_end(subtilis_lexer_t *l,
 static void prv_process_decimal(subtilis_lexer_t *l, char ch,
 				subtilis_token_t *t, subtilis_error_t *err)
 {
-	prv_set_first(l, t, ch, SUBTILIS_TOKEN_INTEGER);
+	prv_set_first(l, t, SUBTILIS_TOKEN_INTEGER);
 	if (!prv_extract_number(l, t, prv_decimal_end, err))
 		return;
 
@@ -323,21 +340,19 @@ static void prv_process_binary(subtilis_lexer_t *l, subtilis_token_t *t,
 	prv_parse_integer(l, t, 2, err);
 }
 
-/* TODO: This code is wrong could lead to loop terminating early */
 static void prv_process_string(subtilis_lexer_t *l, subtilis_token_t *t,
 			       subtilis_error_t *err)
 {
+	const char *tbuf;
+
 	l->index++;
 	t->type = SUBTILIS_TOKEN_STRING;
 	do {
 		prv_ensure_buffer(l, err);
 		if (err->type != SUBTILIS_ERROR_OK)
 			return;
-		if (l->index == l->buf_end) {
-			subtilis_error_set_unterminated_string(
-			    err, t->buf, l->stream->name, l->line);
-			return;
-		}
+		if (l->index == l->buf_end)
+			goto unterminated;
 
 		while (l->index < l->buf_end) {
 			if (l->buffer[l->index] == '"') {
@@ -346,20 +361,21 @@ static void prv_process_string(subtilis_lexer_t *l, subtilis_token_t *t,
 					goto done;
 				l->index++;
 			}
-			if (t->token_size == SUBTILIS_MAX_TOKEN_SIZE) {
-				subtilis_error_set_string_too_long(
-				    err, t->buf, l->stream->name, l->line);
-				t->buf[t->token_size] = 0;
+			prv_set_next_with_err(l, t, err);
+			if (err->type != SUBTILIS_ERROR_OK)
 				return;
-			}
-			t->buf[t->token_size++] = l->buffer[l->index++];
 		}
 	} while (l->index == l->buf_end);
 
 done:
-
 	l->index++;
-	t->buf[t->token_size] = 0;
+
+	return;
+
+unterminated:
+	tbuf = subtilis_token_get_text(t);
+	subtilis_error_set_unterminated_string(err, tbuf, l->stream->name,
+					       l->line);
 }
 
 static int prv_compare_keyword(const void *a, const void *b)
@@ -390,41 +406,41 @@ static void prv_validate_identifier(subtilis_lexer_t *l, subtilis_token_t *t,
 					SUBTILIS_ERROR_IDENTIFIER_TOO_LONG);
 		if (err->type != SUBTILIS_ERROR_OK)
 			return;
-		t->buf[t->token_size++] = l->buffer[l->index++];
+		prv_set_next(l, t);
 	}
 
-	if (l->index < l->buf_end) {
-		if (ch == '$')
-			t->tok.id_type = SUBTILIS_IDENTIFIER_STRING;
-		else if (ch == '%')
-			t->tok.id_type = SUBTILIS_IDENTIFIER_INTEGER;
-		else
-			t->tok.id_type = SUBTILIS_IDENTIFIER_REAL;
+	if (l->index == l->buf_end) {
+		t->tok.id_type = SUBTILIS_IDENTIFIER_REAL;
+		return;
+	}
 
-		if (t->tok.id_type != SUBTILIS_IDENTIFIER_REAL) {
-			prv_ensure_token_buffer(
-			    l, t, err, SUBTILIS_ERROR_IDENTIFIER_TOO_LONG);
-			if (err->type != SUBTILIS_ERROR_OK)
-				return;
-			t->buf[t->token_size++] = l->buffer[l->index++];
-		}
+	if (ch == '$') {
+		t->tok.id_type = SUBTILIS_IDENTIFIER_STRING;
+	} else if (ch == '%') {
+		t->tok.id_type = SUBTILIS_IDENTIFIER_INTEGER;
 	} else {
 		t->tok.id_type = SUBTILIS_IDENTIFIER_REAL;
+		return;
 	}
 
-	t->buf[t->token_size] = 0;
+	prv_ensure_token_buffer(l, t, err, SUBTILIS_ERROR_IDENTIFIER_TOO_LONG);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+	prv_set_next(l, t);
 }
 
 static void prv_process_identifier(subtilis_lexer_t *l, char ch,
 				   subtilis_token_t *t, subtilis_error_t *err)
 {
-	prv_set_first(l, t, ch, SUBTILIS_TOKEN_IDENTIFIER);
+	prv_set_first(l, t, SUBTILIS_TOKEN_IDENTIFIER);
 	prv_validate_identifier(l, t, err);
 }
 
 static void prv_process_call(subtilis_lexer_t *l, subtilis_token_t *t,
 			     bool possible_proc, subtilis_error_t *err)
 {
+	const char *tbuf;
+
 	t->type = SUBTILIS_TOKEN_KEYWORD;
 	prv_validate_identifier(l, t, err);
 	if (err->type != SUBTILIS_ERROR_OK)
@@ -432,16 +448,18 @@ static void prv_process_call(subtilis_lexer_t *l, subtilis_token_t *t,
 
 	if (possible_proc) {
 		if (t->tok.id_type != SUBTILIS_IDENTIFIER_REAL) {
+			tbuf = subtilis_token_get_text(t);
 			subtilis_error_set_bad_proc_name(
-			    err, t->buf, l->stream->name, l->line);
+			    err, tbuf, l->stream->name, l->line);
 			return;
 		}
 		t->tok.keyword.type = SUBTILIS_KEYWORD_PROC;
 		t->tok.keyword.supported = true;
 	} else {
 		if (t->tok.id_type != SUBTILIS_IDENTIFIER_REAL) {
+			tbuf = subtilis_token_get_text(t);
 			subtilis_error_set_bad_fn_name(
-			    err, t->buf, l->stream->name, l->line);
+			    err, tbuf, l->stream->name, l->line);
 			return;
 		}
 		t->tok.keyword.type = SUBTILIS_KEYWORD_FN;
@@ -457,10 +475,12 @@ static void prv_process_keyword(subtilis_lexer_t *l, char ch,
 	bool possible_id = true;
 	bool possible_fn = false;
 	bool possible_proc = false;
+	const char *tbuf;
+	size_t len;
 
-	prv_set_first(l, t, ch, SUBTILIS_TOKEN_UNKNOWN);
+	prv_set_first(l, t, SUBTILIS_TOKEN_UNKNOWN);
 
-	// TODO: We have very similar loops elsewhere
+	/* TODO: We have very similar loops elsewhere */
 	for (;;) {
 		prv_ensure_buffer(l, err);
 		if (err->type != SUBTILIS_ERROR_OK)
@@ -475,7 +495,7 @@ static void prv_process_keyword(subtilis_lexer_t *l, char ch,
 					SUBTILIS_ERROR_IDENTIFIER_TOO_LONG);
 		if (err->type != SUBTILIS_ERROR_OK)
 			return;
-		t->buf[t->token_size++] = l->buffer[l->index++];
+		prv_set_next(l, t);
 	}
 
 	if (l->index < l->buf_end) {
@@ -484,7 +504,7 @@ static void prv_process_keyword(subtilis_lexer_t *l, char ch,
 			    l, t, err, SUBTILIS_ERROR_IDENTIFIER_TOO_LONG);
 			if (err->type != SUBTILIS_ERROR_OK)
 				return;
-			t->buf[t->token_size++] = l->buffer[l->index++];
+			prv_set_next(l, t);
 			possible_id = false;
 			prv_ensure_buffer(l, err);
 			if (err->type != SUBTILIS_ERROR_OK)
@@ -496,31 +516,39 @@ static void prv_process_keyword(subtilis_lexer_t *l, char ch,
 				    SUBTILIS_ERROR_IDENTIFIER_TOO_LONG);
 				if (err->type != SUBTILIS_ERROR_OK)
 					return;
-				t->buf[t->token_size++] = l->buffer[l->index++];
+				prv_set_next(l, t);
 			}
 		} else if (ch == '#') {
 			prv_ensure_token_buffer(
 			    l, t, err, SUBTILIS_ERROR_IDENTIFIER_TOO_LONG);
 			if (err->type != SUBTILIS_ERROR_OK)
 				return;
-			t->buf[t->token_size++] = l->buffer[l->index++];
+			prv_set_next(l, t);
 		}
 	}
 
-	t->buf[t->token_size] = 0;
+	/* This will zero terminate the token buffer.  This is what we need
+	 * for performing the various string comparsions we're going to do
+	 * but we'll need to remove the trailing zero if we don't have a
+	 * keyword.
+	 */
+
+	tbuf = subtilis_token_get_text(t);
+	len = subtilis_buffer_get_size(&t->buf);
 
 	// TODO: bsearch may not be efficient for large files.
 
 	if (possible_id) {
-		possible_proc = strncmp(t->buf, "PROC", 4) == 0;
-		possible_fn = strncmp(t->buf, "FN", 2) == 0;
+		possible_proc = strncmp(tbuf, "PROC", 4) == 0;
+		possible_fn = strncmp(tbuf, "FN", 2) == 0;
 		if (possible_proc || possible_fn) {
+			subtilis_buffer_remove_terminator(&t->buf);
 			prv_process_call(l, t, possible_proc, err);
 			return;
 		}
 	}
 
-	key.str = t->buf;
+	key.str = subtilis_token_get_text(t);
 	kw =
 	    bsearch(&key, subtilis_keywords_list,
 		    sizeof(subtilis_keywords_list) / sizeof(subtilis_keyword_t),
@@ -529,8 +557,9 @@ static void prv_process_keyword(subtilis_lexer_t *l, char ch,
 	if (!kw) {
 		if (!possible_id) {
 			subtilis_error_set_unknown_token(
-			    err, t->buf, l->stream->name, l->line);
+			    err, tbuf, l->stream->name, l->line);
 		} else {
+			subtilis_buffer_remove_terminator(&t->buf);
 			t->type = SUBTILIS_TOKEN_IDENTIFIER;
 			prv_validate_identifier(l, t, err);
 		}
@@ -544,7 +573,9 @@ static void prv_process_keyword(subtilis_lexer_t *l, char ch,
 static void prv_process_unknown(subtilis_lexer_t *l, char ch,
 				subtilis_token_t *t, subtilis_error_t *err)
 {
-	prv_set_first(l, t, ch, SUBTILIS_TOKEN_UNKNOWN);
+	const char *tbuf;
+
+	prv_set_first(l, t, SUBTILIS_TOKEN_UNKNOWN);
 	for (;;) {
 		prv_ensure_buffer(l, err);
 		if (err->type != SUBTILIS_ERROR_OK)
@@ -559,11 +590,11 @@ static void prv_process_unknown(subtilis_lexer_t *l, char ch,
 					SUBTILIS_ERROR_UNKNOWN_TOKEN);
 		if (err->type != SUBTILIS_ERROR_OK)
 			return;
-		t->buf[t->token_size++] = l->buffer[l->index++];
+		prv_set_next(l, t);
 	}
 
-	t->buf[t->token_size] = 0;
-	subtilis_error_set_unknown_token(err, t->buf, l->stream->name, l->line);
+	tbuf = subtilis_token_get_text(t);
+	subtilis_error_set_unknown_token(err, tbuf, l->stream->name, l->line);
 }
 
 static void prv_process_token(subtilis_lexer_t *l, subtilis_token_t *t,
@@ -572,12 +603,12 @@ static void prv_process_token(subtilis_lexer_t *l, subtilis_token_t *t,
 	char ch = l->buffer[l->index];
 
 	if (prv_is_simple_operator(ch)) {
-		prv_set_first(l, t, ch, SUBTILIS_TOKEN_OPERATOR);
+		prv_set_first(l, t, SUBTILIS_TOKEN_OPERATOR);
 		return;
 	}
 
 	if (ch == '<' || ch == '>' || ch == '+' || ch == '-') {
-		prv_process_complex_operator(l, ch, t, err);
+		prv_process_complex_operator(l, t, err);
 		return;
 	}
 
@@ -638,32 +669,64 @@ static void prv_skip_white(subtilis_lexer_t *l, subtilis_error_t *err)
 	} while (prv_is_whitespace(l->buffer[l->index]));
 }
 
-void subtilis_init_token(subtilis_token_t *t)
+subtilis_token_t *subtilis_token_new(subtilis_error_t *err)
+{
+	subtilis_token_t *t;
+
+	t = malloc(sizeof(*t));
+	if (!t) {
+		subtilis_error_set_oom(err);
+		return NULL;
+	}
+
+	t->type = SUBTILIS_TOKEN_EOF;
+	memset(&t->tok, 0, sizeof(t->tok));
+	subtilis_buffer_init(&t->buf, SUBTILIS_MAX_TOKEN_SIZE + 1);
+	subtilis_buffer_reserve(&t->buf, SUBTILIS_MAX_TOKEN_SIZE + 1, err);
+	if (err->type != SUBTILIS_ERROR_OK) {
+		subtilis_buffer_free(&t->buf);
+		free(t);
+		t = NULL;
+	}
+	return t;
+}
+
+void subtilis_token_delete(subtilis_token_t *t)
+{
+	if (!t)
+		return;
+
+	subtilis_buffer_free(&t->buf);
+	free(t);
+}
+
+static void prv_reinit_token(subtilis_token_t *t)
 {
 	t->type = SUBTILIS_TOKEN_EOF;
-	t->buf[0] = 0;
-	t->token_size = 0;
 	memset(&t->tok, 0, sizeof(t->tok));
+	subtilis_buffer_reset(&t->buf);
 }
 
 void subtilis_dump_token(subtilis_token_t *t)
 {
+	const char *tbuf = subtilis_token_get_text(t);
+
 	if (t->type == SUBTILIS_TOKEN_INTEGER)
-		printf("[%d %d %s]\n", t->type, t->tok.integer, t->buf);
+		printf("[%d %d %s]\n", t->type, t->tok.integer, tbuf);
 	else if (t->type == SUBTILIS_TOKEN_REAL)
-		printf("[%d %f %s]\n", t->type, t->tok.real, t->buf);
+		printf("[%d %f %s]\n", t->type, t->tok.real, tbuf);
 	else if (t->type == SUBTILIS_TOKEN_KEYWORD)
-		printf("[%d %d %s]\n", t->type, t->tok.keyword.type, t->buf);
+		printf("[%d %d %s]\n", t->type, t->tok.keyword.type, tbuf);
 	else if (t->type == SUBTILIS_TOKEN_IDENTIFIER)
-		printf("[%d %d %s]\n", t->type, t->tok.id_type, t->buf);
+		printf("[%d %d %s]\n", t->type, t->tok.id_type, tbuf);
 	else
-		printf("[%d %s]\n", t->type, t->buf);
+		printf("[%d %s]\n", t->type, tbuf);
 }
 
 void subtilis_lexer_get(subtilis_lexer_t *l, subtilis_token_t *t,
 			subtilis_error_t *err)
 {
-	subtilis_init_token(t);
+	prv_reinit_token(t);
 	prv_skip_white(l, err);
 	if ((err->type != SUBTILIS_ERROR_OK) || (l->index == l->buf_end))
 		return;

--- a/lexer.h
+++ b/lexer.h
@@ -19,8 +19,11 @@
 
 #include <stdint.h>
 
+#include "buffer.h"
 #include "keywords.h"
 #include "stream.h"
+
+/* Does not apply to strings which are limitless in size */
 
 #define SUBTILIS_MAX_TOKEN_SIZE 255
 
@@ -68,8 +71,7 @@ struct _subtilis_token_t {
 		double real;
 		subtilis_identifier_type_t id_type;
 	} tok;
-	char buf[SUBTILIS_MAX_TOKEN_SIZE + 1];
-	size_t token_size;
+	subtilis_buffer_t buf;
 };
 
 typedef struct _subtilis_token_t subtilis_token_t;
@@ -80,7 +82,9 @@ subtilis_lexer_t *subtilis_lexer_new(subtilis_stream_t *s, size_t buf_size,
 void subtilis_lexer_delete(subtilis_lexer_t *l, subtilis_error_t *err);
 void subtilis_lexer_get(subtilis_lexer_t *l, subtilis_token_t *t,
 			subtilis_error_t *err);
-void subtilis_init_token(subtilis_token_t *t);
+subtilis_token_t *subtilis_token_new(subtilis_error_t *err);
+const char *subtilis_token_get_text(subtilis_token_t *t);
+void subtilis_token_delete(subtilis_token_t *t);
 void subtilis_dump_token(subtilis_token_t *t);
 
 #endif

--- a/lexer.h
+++ b/lexer.h
@@ -84,6 +84,8 @@ void subtilis_lexer_get(subtilis_lexer_t *l, subtilis_token_t *t,
 			subtilis_error_t *err);
 subtilis_token_t *subtilis_token_new(subtilis_error_t *err);
 const char *subtilis_token_get_text(subtilis_token_t *t);
+const char *subtilis_token_get_text_with_err(subtilis_token_t *t,
+					     subtilis_error_t *err);
 void subtilis_token_delete(subtilis_token_t *t);
 void subtilis_dump_token(subtilis_token_t *t);
 

--- a/lexer_test.c
+++ b/lexer_test.c
@@ -64,20 +64,12 @@ static int prv_test_too_long(subtilis_lexer_t *l, subtilis_token_t *t,
 			     subtilis_error_type_t err_type)
 {
 	subtilis_error_t err;
-	const char *tbuf;
 
 	subtilis_error_init(&err);
 	subtilis_lexer_get(l, t, &err);
 	if (err.type != err_type) {
 		fprintf(stderr, "Expected error %d got %d\n", err_type,
 			err.type);
-		return 1;
-	}
-
-	tbuf = subtilis_token_get_text(t);
-	if (strlen(tbuf) > SUBTILIS_MAX_TOKEN_SIZE) {
-		fprintf(stderr, "Token overflow.  l->token_size = %zu\n",
-			subtilis_buffer_get_size(&t->buf));
 		return 1;
 	}
 

--- a/lexer_test.c
+++ b/lexer_test.c
@@ -22,15 +22,20 @@
 #include "lexer.h"
 
 static int prv_test_wrapper(const char *text, size_t buf_size,
-			    int (*fn)(subtilis_lexer_t *))
+			    int (*fn)(subtilis_lexer_t *, subtilis_token_t *))
 {
 	subtilis_stream_t s;
 	subtilis_error_t err;
 	subtilis_lexer_t *l;
+	subtilis_token_t *t = NULL;
 	int retval;
 
 	subtilis_error_init(&err);
 	subtilis_stream_from_text(&s, text, &err);
+	if (err.type != SUBTILIS_ERROR_OK)
+		goto fail;
+
+	t = subtilis_token_new(&err);
 	if (err.type != SUBTILIS_ERROR_OK)
 		goto fail;
 
@@ -39,13 +44,15 @@ static int prv_test_wrapper(const char *text, size_t buf_size,
 		s.close(s.handle, &err);
 		goto fail;
 	}
-	retval = fn(l);
+	retval = fn(l, t);
 	subtilis_lexer_delete(l, &err);
+	subtilis_token_delete(t);
 	printf(": [%s]\n", retval ? "FAIL" : "OK");
 
 	return retval;
 
 fail:
+	subtilis_token_delete(t);
 
 	printf(": [FAIL]\n");
 	subtilis_error_fprintf(stderr, &err, true);
@@ -53,79 +60,76 @@ fail:
 	return 1;
 }
 
-static int prv_test_too_long(subtilis_lexer_t *l,
+static int prv_test_too_long(subtilis_lexer_t *l, subtilis_token_t *t,
 			     subtilis_error_type_t err_type)
 {
-	subtilis_token_t t;
 	subtilis_error_t err;
+	const char *tbuf;
 
 	subtilis_error_init(&err);
-	subtilis_lexer_get(l, &t, &err);
+	subtilis_lexer_get(l, t, &err);
 	if (err.type != err_type) {
 		fprintf(stderr, "Expected error %d got %d\n", err_type,
 			err.type);
 		return 1;
 	}
 
-	if (t.token_size > SUBTILIS_MAX_TOKEN_SIZE) {
+	tbuf = subtilis_token_get_text(t);
+	if (strlen(tbuf) > SUBTILIS_MAX_TOKEN_SIZE) {
 		fprintf(stderr, "Token overflow.  l->token_size = %zu\n",
-			t.token_size);
+			subtilis_buffer_get_size(&t->buf));
 		return 1;
 	}
 
 	return 0;
 }
 
-static int prv_check_string_too_long(subtilis_lexer_t *l)
+static int prv_check_id_too_long(subtilis_lexer_t *l, subtilis_token_t *t)
 {
-	return prv_test_too_long(l, SUBTILIS_ERROR_STRING_TOO_LONG);
+	return prv_test_too_long(l, t, SUBTILIS_ERROR_IDENTIFIER_TOO_LONG);
 }
 
-static int prv_check_id_too_long(subtilis_lexer_t *l)
-{
-	return prv_test_too_long(l, SUBTILIS_ERROR_IDENTIFIER_TOO_LONG);
-}
-
-static int prv_test_max_id(subtilis_lexer_t *l,
+static int prv_test_max_id(subtilis_lexer_t *l, subtilis_token_t *t,
 			   subtilis_identifier_type_t id_type)
 {
-	subtilis_token_t t;
 	subtilis_error_t err;
+	const char *tbuf;
 
 	subtilis_error_init(&err);
-	subtilis_lexer_get(l, &t, &err);
+	subtilis_lexer_get(l, t, &err);
 	if (err.type != SUBTILIS_ERROR_OK) {
 		subtilis_error_fprintf(stderr, &err, true);
 		return 1;
 	}
 
-	if ((t.type != SUBTILIS_TOKEN_IDENTIFIER) ||
-	    (t.tok.id_type != id_type)) {
+	if ((t->type != SUBTILIS_TOKEN_IDENTIFIER) ||
+	    (t->tok.id_type != id_type)) {
 		fprintf(stderr,
 			"Unexpected token.  Expected identifier of type %d\n",
 			id_type);
 		return 1;
 	}
 
-	subtilis_lexer_get(l, &t, &err);
+	subtilis_lexer_get(l, t, &err);
 	if (err.type != SUBTILIS_ERROR_OK) {
 		subtilis_error_fprintf(stderr, &err, true);
 		return 1;
 	}
 
-	if ((t.type != SUBTILIS_TOKEN_OPERATOR) || (strcmp(t.buf, "+"))) {
+	tbuf = subtilis_token_get_text(t);
+	if ((t->type != SUBTILIS_TOKEN_OPERATOR) || (strcmp(tbuf, "+"))) {
 		fprintf(stderr, "Unexpected token.  Expected +\n");
 		return 1;
 	}
 
-	subtilis_lexer_get(l, &t, &err);
+	subtilis_lexer_get(l, t, &err);
 	if (err.type != SUBTILIS_ERROR_OK) {
 		subtilis_error_fprintf(stderr, &err, true);
 		return 1;
 	}
 
-	if ((t.type != SUBTILIS_TOKEN_IDENTIFIER) ||
-	    (t.tok.id_type != id_type)) {
+	if ((t->type != SUBTILIS_TOKEN_IDENTIFIER) ||
+	    (t->tok.id_type != id_type)) {
 		fprintf(stderr,
 			"Unexpected token.  Expected identifier of type %d\n",
 			id_type);
@@ -135,33 +139,19 @@ static int prv_test_max_id(subtilis_lexer_t *l,
 	return 0;
 }
 
-static int prv_check_max_int_var(subtilis_lexer_t *l)
+static int prv_check_max_int_var(subtilis_lexer_t *l, subtilis_token_t *t)
 {
-	return prv_test_max_id(l, SUBTILIS_IDENTIFIER_INTEGER);
+	return prv_test_max_id(l, t, SUBTILIS_IDENTIFIER_INTEGER);
 }
 
-static int prv_check_max_str_var(subtilis_lexer_t *l)
+static int prv_check_max_str_var(subtilis_lexer_t *l, subtilis_token_t *t)
 {
-	return prv_test_max_id(l, SUBTILIS_IDENTIFIER_STRING);
+	return prv_test_max_id(l, t, SUBTILIS_IDENTIFIER_STRING);
 }
 
-static int prv_check_max_real_var(subtilis_lexer_t *l)
+static int prv_check_max_real_var(subtilis_lexer_t *l, subtilis_token_t *t)
 {
-	return prv_test_max_id(l, SUBTILIS_IDENTIFIER_REAL);
-}
-
-static int prv_test_string_too_long(void)
-{
-	char str[SUBTILIS_MAX_TOKEN_SIZE + 4];
-
-	str[0] = '"';
-	str[SUBTILIS_MAX_TOKEN_SIZE + 3] = 0;
-	str[SUBTILIS_MAX_TOKEN_SIZE + 2] = '"';
-	memset(&str[1], '1', SUBTILIS_MAX_TOKEN_SIZE + 1);
-
-	printf("lexer_string_too_long");
-	return prv_test_wrapper(str, SUBTILIS_CONFIG_LEXER_BUF_SIZE,
-				prv_check_string_too_long);
+	return prv_test_max_id(l, t, SUBTILIS_IDENTIFIER_REAL);
 }
 
 static int prv_test_real_var_too_long(void)
@@ -302,39 +292,38 @@ static int prv_test_max_real_var(void)
 				prv_check_max_real_var);
 }
 
-static int prv_check_keywords(subtilis_lexer_t *l)
+static int prv_check_keywords(subtilis_lexer_t *l, subtilis_token_t *t)
 {
-	subtilis_token_t t;
 	subtilis_error_t err;
 	int i;
 
 	subtilis_error_init(&err);
 
 	for (i = 0; i < SUBTILIS_KEYWORD_MAX; i++) {
-		subtilis_lexer_get(l, &t, &err);
+		subtilis_lexer_get(l, t, &err);
 		if (err.type != SUBTILIS_ERROR_OK) {
 			subtilis_error_fprintf(stderr, &err, true);
 			return 1;
 		}
 
-		if (t.type != SUBTILIS_TOKEN_KEYWORD) {
+		if (t->type != SUBTILIS_TOKEN_KEYWORD) {
 			fprintf(stderr, "Expected token type %d got %d\n",
-				t.type, SUBTILIS_TOKEN_KEYWORD);
+				t->type, SUBTILIS_TOKEN_KEYWORD);
 			return 1;
 		}
 
-		if (t.tok.keyword.type != subtilis_keywords_list[i].type) {
+		if (t->tok.keyword.type != subtilis_keywords_list[i].type) {
 			fprintf(stderr, "Expected keyword type %d got %d\n",
 				subtilis_keywords_list[i].type,
-				t.tok.keyword.type);
+				t->tok.keyword.type);
 			return 1;
 		}
 
-		if (t.tok.keyword.supported !=
+		if (t->tok.keyword.supported !=
 		    subtilis_keywords_list[i].supported) {
 			fprintf(stderr, "Expected supported %d got %d\n",
 				subtilis_keywords_list[i].supported,
-				t.tok.keyword.supported);
+				t->tok.keyword.supported);
 			return 1;
 		}
 	}
@@ -390,40 +379,41 @@ on_error:
 	return 1;
 }
 
-static int prv_check_procedure_call(subtilis_lexer_t *l)
+static int prv_check_procedure_call(subtilis_lexer_t *l, subtilis_token_t *t)
 {
-	subtilis_token_t t;
 	subtilis_error_t err;
 	int i;
 	const char *const names[] = {"PROCINVOKEME", "PROCinvokeme"};
+	const char *tbuf;
 
 	subtilis_error_init(&err);
 
 	for (i = 0; i < 2; i++) {
-		subtilis_lexer_get(l, &t, &err);
+		subtilis_lexer_get(l, t, &err);
 		if (err.type != SUBTILIS_ERROR_OK) {
 			subtilis_error_fprintf(stderr, &err, true);
 			return 1;
 		}
 
-		if (t.type != SUBTILIS_TOKEN_KEYWORD) {
+		if (t->type != SUBTILIS_TOKEN_KEYWORD) {
 			fprintf(stderr,
 				"SUBTILIS_TOKEN_KEYWORD expected.  Found %d\n",
-				t.type);
+				t->type);
 			return 1;
 		}
 
-		if (t.tok.keyword.type != SUBTILIS_KEYWORD_PROC) {
+		if (t->tok.keyword.type != SUBTILIS_KEYWORD_PROC) {
 			fprintf(stderr,
 				"SUBTILIS_TOKEN_KEYWORD expected.  Found %d\n",
-				t.tok.keyword.type);
+				t->tok.keyword.type);
 			return 1;
 		}
 
-		if (strcmp(names[i], t.buf)) {
+		tbuf = subtilis_token_get_text(t);
+		if (strcmp(names[i], tbuf)) {
 			fprintf(stderr,
 				"Unexpected procedure name %s, expected %s\n",
-				t.buf, names[i]);
+				tbuf, names[i]);
 			return 1;
 		}
 	}
@@ -431,21 +421,20 @@ static int prv_check_procedure_call(subtilis_lexer_t *l)
 	return 0;
 }
 
-static int prv_check_empty(subtilis_lexer_t *l)
+static int prv_check_empty(subtilis_lexer_t *l, subtilis_token_t *t)
 {
-	subtilis_token_t t;
 	subtilis_error_t err;
 
 	subtilis_error_init(&err);
 
-	subtilis_lexer_get(l, &t, &err);
+	subtilis_lexer_get(l, t, &err);
 	if (err.type != SUBTILIS_ERROR_OK) {
 		subtilis_error_fprintf(stderr, &err, true);
 		return 1;
 	}
 
-	if (t.type != SUBTILIS_TOKEN_EOF) {
-		fprintf(stderr, "EOF expected, found %d\n", t.type);
+	if (t->type != SUBTILIS_TOKEN_EOF) {
+		fprintf(stderr, "EOF expected, found %d\n", t->type);
 		return 1;
 	}
 
@@ -470,16 +459,15 @@ static int prv_test_empty(void)
 				prv_check_empty);
 }
 
-static int prv_check_bad_proc_name(subtilis_lexer_t *l,
+static int prv_check_bad_proc_name(subtilis_lexer_t *l, subtilis_token_t *t,
 				   subtilis_error_type_t err_type)
 {
-	subtilis_token_t t;
 	subtilis_error_t err;
 	int i;
 
 	for (i = 0; i < 2; i++) {
 		subtilis_error_init(&err);
-		subtilis_lexer_get(l, &t, &err);
+		subtilis_lexer_get(l, t, &err);
 		if (err.type != err_type) {
 			fprintf(stderr, "Expected error %d, got %d\n", err_type,
 				err.type);
@@ -490,9 +478,9 @@ static int prv_check_bad_proc_name(subtilis_lexer_t *l,
 	return 0;
 }
 
-static int prv_check_proc_typed(subtilis_lexer_t *l)
+static int prv_check_proc_typed(subtilis_lexer_t *l, subtilis_token_t *t)
 {
-	return prv_check_bad_proc_name(l, SUBTILIS_ERROR_BAD_PROC_NAME);
+	return prv_check_bad_proc_name(l, t, SUBTILIS_ERROR_BAD_PROC_NAME);
 }
 
 static int prv_test_proc_typed(void)
@@ -504,9 +492,9 @@ static int prv_test_proc_typed(void)
 				prv_check_proc_typed);
 }
 
-static int prv_check_fn_typed(subtilis_lexer_t *l)
+static int prv_check_fn_typed(subtilis_lexer_t *l, subtilis_token_t *t)
 {
-	return prv_check_bad_proc_name(l, SUBTILIS_ERROR_BAD_FN_NAME);
+	return prv_check_bad_proc_name(l, t, SUBTILIS_ERROR_BAD_FN_NAME);
 }
 
 static int prv_test_fn_typed(void)
@@ -518,11 +506,11 @@ static int prv_test_fn_typed(void)
 				prv_check_fn_typed);
 }
 
-static int prv_check_int(subtilis_lexer_t *l)
+static int prv_check_int(subtilis_lexer_t *l, subtilis_token_t *t)
 {
-	subtilis_token_t t;
 	subtilis_error_t err;
 	int i;
+	const char *tbuf;
 
 	const int expected[] = {
 	    12345, 67890, 0x12345, 0x67890, 0xabcef, 2147483647, 170,
@@ -532,54 +520,55 @@ static int prv_check_int(subtilis_lexer_t *l)
 
 	subtilis_error_init(&err);
 	for (i = 0; i < sizeof(expected) / sizeof(int); i++) {
-		subtilis_lexer_get(l, &t, &err);
+		subtilis_lexer_get(l, t, &err);
 		if (err.type != SUBTILIS_ERROR_OK) {
 			subtilis_error_fprintf(stderr, &err, true);
 			return 1;
 		}
 
-		if (t.type != SUBTILIS_TOKEN_INTEGER) {
+		if (t->type != SUBTILIS_TOKEN_INTEGER) {
 			fprintf(stderr, "Expected token type %d, got %d\n",
-				SUBTILIS_TOKEN_INTEGER, t.type);
+				SUBTILIS_TOKEN_INTEGER, t->type);
 			return 1;
 		}
 
-		if (t.tok.integer != expected[i]) {
+		if (t->tok.integer != expected[i]) {
 			fprintf(stderr, "Expected integer value %d, got %d\n",
-				expected[i], t.tok.integer);
+				expected[i], t->tok.integer);
 			return 1;
 		}
 	}
 
 	for (i = 0; i < sizeof(expected_signed) / sizeof(int); i++) {
-		subtilis_lexer_get(l, &t, &err);
+		subtilis_lexer_get(l, t, &err);
 		if (err.type != SUBTILIS_ERROR_OK) {
 			subtilis_error_fprintf(stderr, &err, true);
 			return 1;
 		}
 
-		if (t.type != SUBTILIS_TOKEN_OPERATOR) {
+		if (t->type != SUBTILIS_TOKEN_OPERATOR) {
 			fprintf(stderr, "Expected token type %d, got %d\n",
-				SUBTILIS_TOKEN_OPERATOR, t.type);
+				SUBTILIS_TOKEN_OPERATOR, t->type);
 			return 1;
 		}
 
-		if (strcmp(t.buf, "-")) {
+		tbuf = subtilis_token_get_text(t);
+		if (strcmp(tbuf, "-")) {
 			fprintf(stderr, "Expected operator '-', got '%s'\n",
-				t.buf);
+				tbuf);
 			return 1;
 		}
 
-		subtilis_lexer_get(l, &t, &err);
-		if (t.type != SUBTILIS_TOKEN_INTEGER) {
+		subtilis_lexer_get(l, t, &err);
+		if (t->type != SUBTILIS_TOKEN_INTEGER) {
 			fprintf(stderr, "Expected token type %d, got %d\n",
-				SUBTILIS_TOKEN_INTEGER, t.type);
+				SUBTILIS_TOKEN_INTEGER, t->type);
 			return 1;
 		}
 
-		if (t.tok.integer != expected_signed[i]) {
+		if (t->tok.integer != expected_signed[i]) {
 			fprintf(stderr, "Expected integer value %d, got %d\n",
-				expected_signed[i], t.tok.integer);
+				expected_signed[i], t->tok.integer);
 			return 1;
 		}
 	}
@@ -597,10 +586,10 @@ static int prv_test_int(void)
 				prv_check_int);
 }
 
-static int prv_check_real(subtilis_lexer_t *l)
+static int prv_check_real(subtilis_lexer_t *l, subtilis_token_t *t)
 {
-	subtilis_token_t t;
 	subtilis_error_t err;
+	const char *tbuf;
 	int i;
 
 	const double expected[] = {
@@ -611,54 +600,55 @@ static int prv_check_real(subtilis_lexer_t *l)
 
 	subtilis_error_init(&err);
 	for (i = 0; i < sizeof(expected) / sizeof(double); i++) {
-		subtilis_lexer_get(l, &t, &err);
+		subtilis_lexer_get(l, t, &err);
 		if (err.type != SUBTILIS_ERROR_OK) {
 			subtilis_error_fprintf(stderr, &err, true);
 			return 1;
 		}
 
-		if (t.type != SUBTILIS_TOKEN_REAL) {
+		if (t->type != SUBTILIS_TOKEN_REAL) {
 			fprintf(stderr, "Expected token type %d, got %d\n",
-				SUBTILIS_TOKEN_REAL, t.type);
+				SUBTILIS_TOKEN_REAL, t->type);
 			return 1;
 		}
 
-		if (fabs(t.tok.real - expected[i]) > 0.001) {
+		if (fabs(t->tok.real - expected[i]) > 0.001) {
 			fprintf(stderr, "Expected real value %lf, got %lf\n",
-				expected[i], t.tok.real);
+				expected[i], t->tok.real);
 			return 1;
 		}
 	}
 
 	for (i = 0; i < sizeof(expected_signed) / sizeof(double); i++) {
-		subtilis_lexer_get(l, &t, &err);
+		subtilis_lexer_get(l, t, &err);
 		if (err.type != SUBTILIS_ERROR_OK) {
 			subtilis_error_fprintf(stderr, &err, true);
 			return 1;
 		}
 
-		if (t.type != SUBTILIS_TOKEN_OPERATOR) {
+		if (t->type != SUBTILIS_TOKEN_OPERATOR) {
 			fprintf(stderr, "Expected token type %d, got %d\n",
-				SUBTILIS_TOKEN_OPERATOR, t.type);
+				SUBTILIS_TOKEN_OPERATOR, t->type);
 			return 1;
 		}
 
-		if (strcmp(t.buf, "-")) {
+		tbuf = subtilis_token_get_text(t);
+		if (strcmp(tbuf, "-")) {
 			fprintf(stderr, "Expected operator '-', got '%s'\n",
-				t.buf);
+				tbuf);
 			return 1;
 		}
 
-		subtilis_lexer_get(l, &t, &err);
-		if (t.type != SUBTILIS_TOKEN_REAL) {
+		subtilis_lexer_get(l, t, &err);
+		if (t->type != SUBTILIS_TOKEN_REAL) {
 			fprintf(stderr, "Expected token type %d, got %d\n",
-				SUBTILIS_TOKEN_REAL, t.type);
+				SUBTILIS_TOKEN_REAL, t->type);
 			return 1;
 		}
 
-		if (fabs(t.tok.real - expected_signed[i]) > 0.001) {
+		if (fabs(t->tok.real - expected_signed[i]) > 0.001) {
 			fprintf(stderr, "Expected real value %lf, got %lf\n",
-				expected_signed[i], t.tok.real);
+				expected_signed[i], t->tok.real);
 			return 1;
 		}
 	}
@@ -675,37 +665,39 @@ static int prv_test_real(void)
 				prv_check_real);
 }
 
-static int prv_check_vars(subtilis_lexer_t *l, const char *const expected[],
-			  size_t len, subtilis_identifier_type_t id_type)
+static int prv_check_vars(subtilis_lexer_t *l, subtilis_token_t *t,
+			  const char *const expected[], size_t len,
+			  subtilis_identifier_type_t id_type)
 {
-	subtilis_token_t t;
 	subtilis_error_t err;
 	int i;
+	const char *tbuf;
 
 	subtilis_error_init(&err);
 	for (i = 0; i < len; i++) {
-		subtilis_lexer_get(l, &t, &err);
+		subtilis_lexer_get(l, t, &err);
 		if (err.type != SUBTILIS_ERROR_OK) {
 			subtilis_error_fprintf(stderr, &err, true);
 			return 1;
 		}
 
-		if (t.type != SUBTILIS_TOKEN_IDENTIFIER) {
+		if (t->type != SUBTILIS_TOKEN_IDENTIFIER) {
 			fprintf(stderr, "Expected token type %d, got %d\n",
-				SUBTILIS_TOKEN_IDENTIFIER, t.type);
+				SUBTILIS_TOKEN_IDENTIFIER, t->type);
 			return 1;
 		}
 
-		if (t.tok.id_type != id_type) {
+		if (t->tok.id_type != id_type) {
 			fprintf(stderr,
 				"Expected variable of type %d, got %d\n",
-				id_type, t.tok.id_type);
+				id_type, t->tok.id_type);
 			return 1;
 		}
 
-		if (strcmp(t.buf, expected[i])) {
+		tbuf = subtilis_token_get_text(t);
+		if (strcmp(tbuf, expected[i])) {
 			fprintf(stderr, "Expected real variable %s, got %s\n",
-				expected[i], t.buf);
+				expected[i], tbuf);
 			return 1;
 		}
 	}
@@ -713,13 +705,13 @@ static int prv_check_vars(subtilis_lexer_t *l, const char *const expected[],
 	return 0;
 }
 
-static int prv_check_real_vars(subtilis_lexer_t *l)
+static int prv_check_real_vars(subtilis_lexer_t *l, subtilis_token_t *t)
 {
 	const char *const expected[] = {
 	    "The",   "quick",	  "brown",     "fox",
 	    "jumps", "over",	   "the",       "lazy",
 	    "dog",   "floating_point", "PROcedure", "index001of2"};
-	return prv_check_vars(l, expected,
+	return prv_check_vars(l, t, expected,
 			      sizeof(expected) / sizeof(const char *const),
 			      SUBTILIS_IDENTIFIER_REAL);
 }
@@ -734,13 +726,13 @@ static int prv_test_real_vars(void)
 				prv_check_real_vars);
 }
 
-static int prv_check_int_vars(subtilis_lexer_t *l)
+static int prv_check_int_vars(subtilis_lexer_t *l, subtilis_token_t *t)
 {
 	const char *const expected[] = {
 	    "The%",   "quick%",		 "brown%",     "fox%",
 	    "jumps%", "over%",		 "the%",       "lazy%",
 	    "dog%",   "floating_point%", "PROcedure%", "index001of2%"};
-	return prv_check_vars(l, expected,
+	return prv_check_vars(l, t, expected,
 			      sizeof(expected) / sizeof(const char *const),
 			      SUBTILIS_IDENTIFIER_INTEGER);
 }
@@ -755,13 +747,13 @@ static int prv_test_int_vars(void)
 				prv_check_int_vars);
 }
 
-static int prv_check_str_vars(subtilis_lexer_t *l)
+static int prv_check_str_vars(subtilis_lexer_t *l, subtilis_token_t *t)
 {
 	const char *const expected[] = {
 	    "The$",   "quick$",		 "brown$",     "fox$",
 	    "jumps$", "over$",		 "the$",       "lazy$",
 	    "dog$",   "floating_point$", "PROcedure$", "index001of2$"};
-	return prv_check_vars(l, expected,
+	return prv_check_vars(l, t, expected,
 			      sizeof(expected) / sizeof(const char *const),
 			      SUBTILIS_IDENTIFIER_STRING);
 }
@@ -776,10 +768,10 @@ static int prv_test_str_vars(void)
 				prv_check_str_vars);
 }
 
-static int prv_check_operators(subtilis_lexer_t *l)
+static int prv_check_operators(subtilis_lexer_t *l, subtilis_token_t *t)
 {
-	subtilis_token_t t;
 	subtilis_error_t err;
+	const char *tbuf;
 	int i;
 
 	const char *const expected[] = {
@@ -790,22 +782,23 @@ static int prv_check_operators(subtilis_lexer_t *l)
 
 	subtilis_error_init(&err);
 	for (i = 0; i < sizeof(expected) / sizeof(const char *); i++) {
-		subtilis_lexer_get(l, &t, &err);
+		subtilis_lexer_get(l, t, &err);
 		if (err.type != SUBTILIS_ERROR_OK) {
 			subtilis_error_fprintf(stderr, &err, true);
 			return 1;
 		}
 
-		if (t.type != SUBTILIS_TOKEN_OPERATOR) {
+		if (t->type != SUBTILIS_TOKEN_OPERATOR) {
 			fprintf(stderr, "Expected token type %d, got %d\n",
-				SUBTILIS_TOKEN_OPERATOR, t.type);
+				SUBTILIS_TOKEN_OPERATOR, t->type);
 			return 1;
 		}
 
-		if (strcmp(t.buf, expected[i])) {
+		tbuf = subtilis_token_get_text(t);
+		if (strcmp(tbuf, expected[i])) {
 			fprintf(stderr,
 				"Expected operator variable %s, got %s\n",
-				expected[i], t.buf);
+				expected[i], tbuf);
 			return 1;
 		}
 	}
@@ -824,13 +817,12 @@ static int prv_test_operators(void)
 				prv_check_operators);
 }
 
-static int prv_check_number_too_large(subtilis_lexer_t *l)
+static int prv_check_number_too_large(subtilis_lexer_t *l, subtilis_token_t *t)
 {
-	subtilis_token_t t;
 	subtilis_error_t err;
 
 	subtilis_error_init(&err);
-	subtilis_lexer_get(l, &t, &err);
+	subtilis_lexer_get(l, t, &err);
 	if (err.type != SUBTILIS_ERROR_NUMBER_TOO_LONG) {
 		fprintf(stderr, "Expected error %d, got %d\n",
 			SUBTILIS_ERROR_NUMBER_TOO_LONG, err.type);
@@ -881,31 +873,33 @@ static int prv_test_number_too_large(void)
 				prv_check_number_too_large);
 }
 
-static int prv_check_strings(subtilis_lexer_t *l)
+static int prv_check_strings(subtilis_lexer_t *l, subtilis_token_t *t)
 {
-	subtilis_token_t t;
 	subtilis_error_t err;
 	int i;
+	const char *tbuf;
 	const char *const expected[] = {
 	    "one two three four five size 0 1 2", "\"No way\", he said",
 	};
 
 	subtilis_error_init(&err);
 	for (i = 0; i < sizeof(expected) / sizeof(const char *); i++) {
-		subtilis_lexer_get(l, &t, &err);
+		subtilis_lexer_get(l, t, &err);
 		if (err.type != SUBTILIS_ERROR_OK) {
 			subtilis_error_fprintf(stderr, &err, true);
 			return 1;
 		}
-		if (t.type != SUBTILIS_TOKEN_STRING) {
+		if (t->type != SUBTILIS_TOKEN_STRING) {
 			fprintf(stderr, "Expected token type %d, got %d\n",
-				SUBTILIS_TOKEN_STRING, t.type);
+				SUBTILIS_TOKEN_STRING, t->type);
 			return 1;
 		}
-		if (strcmp(t.buf, expected[i])) {
+
+		tbuf = subtilis_token_get_text(t);
+		if (strcmp(tbuf, expected[i])) {
 			fprintf(stderr,
 				"Unexpected string constant %s, expected %s\n",
-				t.buf, expected[i]);
+				tbuf, expected[i]);
 			return 1;
 		}
 	}
@@ -923,13 +917,62 @@ static int prv_test_string(void)
 				prv_check_strings);
 }
 
-static int prv_check_string_unterminated(subtilis_lexer_t *l)
+static int prv_check_big_string(subtilis_lexer_t *l, subtilis_token_t *t)
 {
-	subtilis_token_t t;
+	subtilis_error_t err;
+	const size_t content_len = SUBTILIS_MAX_TOKEN_SIZE * 2;
+	char expected[content_len + 1];
+	const char *tbuf;
+
+	memset(&expected[0], '1', content_len);
+	expected[content_len] = 0;
+
+	subtilis_error_init(&err);
+	subtilis_lexer_get(l, t, &err);
+	if (err.type != SUBTILIS_ERROR_OK) {
+		subtilis_error_fprintf(stderr, &err, true);
+		return 1;
+	}
+	if (t->type != SUBTILIS_TOKEN_STRING) {
+		fprintf(stderr, "Expected token type %d, got %d\n",
+			SUBTILIS_TOKEN_STRING, t->type);
+		return 1;
+	}
+
+	tbuf = subtilis_token_get_text(t);
+	if (strcmp(tbuf, expected)) {
+		fprintf(stderr, "Unexpected string constant %s, expected %s\n",
+			tbuf, expected);
+		return 1;
+	}
+
+	return 0;
+}
+
+static int prv_test_big_string(void)
+{
+	subtilis_error_t err;
+	const size_t content_len = SUBTILIS_MAX_TOKEN_SIZE * 2;
+	char str[content_len + 3];
+
+	subtilis_error_init(&err);
+	str[0] = '"';
+	str[content_len + 2] = 0;
+	str[content_len + 1] = '"';
+	memset(&str[1], '1', content_len);
+
+	printf("lexer_big_string");
+	return prv_test_wrapper(str, SUBTILIS_CONFIG_LEXER_BUF_SIZE,
+				prv_check_big_string);
+}
+
+static int prv_check_string_unterminated(subtilis_lexer_t *l,
+					 subtilis_token_t *t)
+{
 	subtilis_error_t err;
 
 	subtilis_error_init(&err);
-	subtilis_lexer_get(l, &t, &err);
+	subtilis_lexer_get(l, t, &err);
 	if (err.type != SUBTILIS_ERROR_UNTERMINATED_STRING) {
 		fprintf(stderr, "Expected err %d, got %d\n",
 			SUBTILIS_ERROR_UNTERMINATED_STRING, err.type);
@@ -948,33 +991,35 @@ static int prv_test_string_unterminated(void)
 				prv_check_string_unterminated);
 }
 
-static int prv_check_unknown(subtilis_lexer_t *l)
+static int prv_check_unknown(subtilis_lexer_t *l, subtilis_token_t *t)
 {
-	subtilis_token_t t;
 	subtilis_error_t err;
 	int i;
+	const char *tbuf;
 	const char *const expected[] = {
 	    "#UNKNOWN", "#1234567890",
 	};
 
 	for (i = 0; i < sizeof(expected) / sizeof(const char *); i++) {
 		subtilis_error_init(&err);
-		subtilis_lexer_get(l, &t, &err);
+		subtilis_lexer_get(l, t, &err);
 		if (err.type != SUBTILIS_ERROR_UNKNOWN_TOKEN) {
 			fprintf(stderr, "Expected err %d, got %d\n",
 				SUBTILIS_ERROR_UNKNOWN_TOKEN, err.type);
 			return 1;
 		}
 
-		if (t.type != SUBTILIS_TOKEN_UNKNOWN) {
+		if (t->type != SUBTILIS_TOKEN_UNKNOWN) {
 			fprintf(stderr, "Expected token type %d, got %d\n",
-				SUBTILIS_TOKEN_UNKNOWN, t.type);
+				SUBTILIS_TOKEN_UNKNOWN, t->type);
 			return 1;
 		}
-		if (strcmp(t.buf, expected[i])) {
+
+		tbuf = subtilis_token_get_text(t);
+		if (strcmp(tbuf, expected[i])) {
 			fprintf(stderr,
 				"Unexpected string constant %s, expected %s\n",
-				t.buf, expected[i]);
+				tbuf, expected[i]);
 			return 1;
 		}
 	}
@@ -1000,7 +1045,6 @@ int main(int argc, char *argv[])
 {
 	int failure = 0;
 
-	failure |= prv_test_string_too_long();
 	failure |= prv_test_real_var_too_long();
 	failure |= prv_test_string_var_too_long();
 	failure |= prv_test_int_var_too_long();
@@ -1026,6 +1070,7 @@ int main(int argc, char *argv[])
 	failure |= prv_test_number_too_large();
 	failure |= prv_test_string();
 	failure |= prv_test_string_unterminated();
+	failure |= prv_test_big_string();
 	failure |= prv_test_unknown();
 
 	return failure;


### PR DESCRIPTION
1. There's no longer any limit on string constant sizes.
2. Tokens are now fully parsed before the max token limitation is applied.
3. The zero termination of the token buffer has been rationalised.