### PR TITLE
Update IR definition

### DIFF
--- a/expression.c
+++ b/expression.c
@@ -44,7 +44,7 @@ subtilis_exp_t *subtilis_exp_new_var(subtilis_exp_type_t type, unsigned int reg,
 		return NULL;
 	}
 	e->type = type;
-	e->exp.reg = reg;
+	e->exp.ir_op.reg = reg;
 
 	return e;
 }
@@ -58,7 +58,7 @@ subtilis_exp_t *subtilis_exp_new_int32(int32_t integer, subtilis_error_t *err)
 		return NULL;
 	}
 	e->type = SUBTILIS_EXP_CONST_INTEGER;
-	e->exp.integer = integer;
+	e->exp.ir_op.integer = integer;
 
 	return e;
 }
@@ -72,7 +72,7 @@ subtilis_exp_t *subtilis_exp_new_real(double real, subtilis_error_t *err)
 		return NULL;
 	}
 	e->type = SUBTILIS_EXP_CONST_REAL;
-	e->exp.real = real;
+	e->exp.ir_op.real = real;
 
 	return e;
 }
@@ -106,10 +106,11 @@ subtilis_exp_t *subtilis_exp_add(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 	case SUBTILIS_EXP_CONST_INTEGER:
 		switch (a2->type) {
 		case SUBTILIS_EXP_CONST_INTEGER:
-			a1->exp.integer += a2->exp.integer;
+			a1->exp.ir_op.integer += a2->exp.ir_op.integer;
 			break;
 		case SUBTILIS_EXP_CONST_REAL:
-			a1->exp.real = ((double)a1->exp.integer) + a2->exp.real;
+			a1->exp.ir_op.real = ((double)a1->exp.ir_op.integer) +
+					     a2->exp.ir_op.real;
 			a1->type = SUBTILIS_EXP_CONST_REAL;
 			break;
 		case SUBTILIS_EXP_CONST_STRING:
@@ -124,10 +125,10 @@ subtilis_exp_t *subtilis_exp_add(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 	case SUBTILIS_EXP_CONST_REAL:
 		switch (a2->type) {
 		case SUBTILIS_EXP_CONST_INTEGER:
-			a1->exp.real += (double)a2->exp.integer;
+			a1->exp.ir_op.real += (double)a2->exp.ir_op.integer;
 			break;
 		case SUBTILIS_EXP_CONST_REAL:
-			a1->exp.real += a2->exp.real;
+			a1->exp.ir_op.real += a2->exp.ir_op.real;
 			break;
 		case SUBTILIS_EXP_CONST_STRING:
 			subtilis_error_set_bad_expression(err, l->stream->name,
@@ -160,9 +161,9 @@ subtilis_exp_t *subtilis_exp_add(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 		switch (a2->type) {
 		case SUBTILIS_EXP_CONST_INTEGER:
 			reg = subtilis_ir_program_add_instr(
-			    p, SUBTILIS_OP_INSTR_ADDI_I32, a1->exp, a2->exp,
-			    err);
-			a1->exp.reg = reg;
+			    p, SUBTILIS_OP_INSTR_ADDI_I32, a1->exp.ir_op,
+			    a2->exp.ir_op, err);
+			a1->exp.ir_op.reg = reg;
 			break;
 		case SUBTILIS_EXP_CONST_REAL:
 		case SUBTILIS_EXP_CONST_STRING:
@@ -171,9 +172,9 @@ subtilis_exp_t *subtilis_exp_add(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 			break;
 		case SUBTILIS_EXP_INTEGER:
 			reg = subtilis_ir_program_add_instr(
-			    p, SUBTILIS_OP_INSTR_ADD_I32, a1->exp, a2->exp,
-			    err);
-			a1->exp.reg = reg;
+			    p, SUBTILIS_OP_INSTR_ADD_I32, a1->exp.ir_op,
+			    a2->exp.ir_op, err);
+			a1->exp.ir_op.reg = reg;
 		case SUBTILIS_EXP_REAL:
 		case SUBTILIS_EXP_STRING:
 			subtilis_error_set_bad_expression(err, l->stream->name,
@@ -217,10 +218,11 @@ subtilis_exp_t *subtilis_exp_mul(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 	case SUBTILIS_EXP_CONST_INTEGER:
 		switch (a2->type) {
 		case SUBTILIS_EXP_CONST_INTEGER:
-			a1->exp.integer *= a2->exp.integer;
+			a1->exp.ir_op.integer *= a2->exp.ir_op.integer;
 			break;
 		case SUBTILIS_EXP_CONST_REAL:
-			a1->exp.real = ((double)a1->exp.integer) * a2->exp.real;
+			a1->exp.ir_op.real = ((double)a1->exp.ir_op.integer) *
+					     a2->exp.ir_op.real;
 			a1->type = SUBTILIS_EXP_CONST_REAL;
 			break;
 		default:
@@ -232,10 +234,10 @@ subtilis_exp_t *subtilis_exp_mul(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 	case SUBTILIS_EXP_CONST_REAL:
 		switch (a2->type) {
 		case SUBTILIS_EXP_CONST_INTEGER:
-			a1->exp.real *= (double)a2->exp.integer;
+			a1->exp.ir_op.real *= (double)a2->exp.ir_op.integer;
 			break;
 		case SUBTILIS_EXP_CONST_REAL:
-			a1->exp.real *= a2->exp.real;
+			a1->exp.ir_op.real *= a2->exp.ir_op.real;
 			break;
 		default:
 			subtilis_error_set_bad_expression(err, l->stream->name,
@@ -251,9 +253,9 @@ subtilis_exp_t *subtilis_exp_mul(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 		switch (a2->type) {
 		case SUBTILIS_EXP_CONST_INTEGER:
 			reg = subtilis_ir_program_add_instr(
-			    p, SUBTILIS_OP_INSTR_MULI_I32, a1->exp, a2->exp,
-			    err);
-			a1->exp.reg = reg;
+			    p, SUBTILIS_OP_INSTR_MULI_I32, a1->exp.ir_op,
+			    a2->exp.ir_op, err);
+			a1->exp.ir_op.reg = reg;
 			break;
 		case SUBTILIS_EXP_CONST_REAL:
 		case SUBTILIS_EXP_CONST_STRING:
@@ -262,9 +264,9 @@ subtilis_exp_t *subtilis_exp_mul(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 			break;
 		case SUBTILIS_EXP_INTEGER:
 			reg = subtilis_ir_program_add_instr(
-			    p, SUBTILIS_OP_INSTR_MUL_I32, a1->exp, a2->exp,
-			    err);
-			a1->exp.reg = reg;
+			    p, SUBTILIS_OP_INSTR_MUL_I32, a1->exp.ir_op,
+			    a2->exp.ir_op, err);
+			a1->exp.ir_op.reg = reg;
 		case SUBTILIS_EXP_REAL:
 		default:
 			subtilis_error_set_bad_expression(err, l->stream->name,
@@ -294,22 +296,25 @@ subtilis_exp_t *subtilis_exp_div(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 {
 	size_t reg;
 
+	// TODO: this can't be correct.  We need to preserve order.
+
 	prv_order_expressions(&a1, &a2);
 
 	switch (a1->type) {
 	case SUBTILIS_EXP_CONST_INTEGER:
 		switch (a2->type) {
 		case SUBTILIS_EXP_CONST_INTEGER:
-			if (a2->exp.integer == 0) {
+			if (a2->exp.ir_op.integer == 0) {
 				subtilis_error_set_divide_by_zero(
 				    err, l->stream->name, l->line);
 				break;
 			}
-			a1->exp.integer /= a2->exp.integer;
+			a1->exp.ir_op.integer /= a2->exp.ir_op.integer;
 			break;
 		case SUBTILIS_EXP_CONST_REAL:
 			/* TODO I need a divide by zero check here? */
-			a1->exp.real = ((double)a1->exp.integer) / a2->exp.real;
+			a1->exp.ir_op.real = ((double)a1->exp.ir_op.integer) /
+					     a2->exp.ir_op.real;
 			a1->type = SUBTILIS_EXP_CONST_REAL;
 			break;
 		default:
@@ -322,11 +327,11 @@ subtilis_exp_t *subtilis_exp_div(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 		switch (a2->type) {
 		case SUBTILIS_EXP_CONST_INTEGER:
 			/* TODO I need a divide by zero check here? */
-			a1->exp.real /= (double)a2->exp.integer;
+			a1->exp.ir_op.real /= (double)a2->exp.ir_op.integer;
 			break;
 		case SUBTILIS_EXP_CONST_REAL:
 			/* TODO I need a divide by zero check here? */
-			a1->exp.real /= a2->exp.real;
+			a1->exp.ir_op.real /= a2->exp.ir_op.real;
 			break;
 		default:
 			subtilis_error_set_bad_expression(err, l->stream->name,
@@ -341,15 +346,15 @@ subtilis_exp_t *subtilis_exp_div(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 	case SUBTILIS_EXP_INTEGER:
 		switch (a2->type) {
 		case SUBTILIS_EXP_CONST_INTEGER:
-			if (a2->exp.integer == 0) {
+			if (a2->exp.ir_op.integer == 0) {
 				subtilis_error_set_divide_by_zero(
 				    err, l->stream->name, l->line);
 				break;
 			}
 			reg = subtilis_ir_program_add_instr(
-			    p, SUBTILIS_OP_INSTR_DIV_I32, a1->exp, a2->exp,
-			    err);
-			a1->exp.reg = reg;
+			    p, SUBTILIS_OP_INSTR_DIV_I32, a1->exp.ir_op,
+			    a2->exp.ir_op, err);
+			a1->exp.ir_op.reg = reg;
 			break;
 		case SUBTILIS_EXP_CONST_REAL:
 		case SUBTILIS_EXP_CONST_STRING:
@@ -358,9 +363,9 @@ subtilis_exp_t *subtilis_exp_div(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 			break;
 		case SUBTILIS_EXP_INTEGER:
 			reg = subtilis_ir_program_add_instr(
-			    p, SUBTILIS_OP_INSTR_DIV_I32, a1->exp, a2->exp,
-			    err);
-			a1->exp.reg = reg;
+			    p, SUBTILIS_OP_INSTR_DIV_I32, a1->exp.ir_op,
+			    a2->exp.ir_op, err);
+			a1->exp.ir_op.reg = reg;
 		case SUBTILIS_EXP_REAL:
 		default:
 			subtilis_error_set_bad_expression(err, l->stream->name,

--- a/expression.h
+++ b/expression.h
@@ -30,9 +30,16 @@ typedef enum {
 	SUBTILIS_EXP_STRING,
 } subtilis_exp_type_t;
 
+union subtilis_exp_operand_t_ {
+	subtilis_ir_operand_t ir_op;
+	subtilis_buffer_t str;
+};
+
+typedef union subtilis_exp_operand_t_ subtilis_exp_operand_t;
+
 struct subtilis_exp_t_ {
 	subtilis_exp_type_t type;
-	subtilis_ir_operand_t exp;
+	subtilis_exp_operand_t exp;
 };
 
 typedef struct subtilis_exp_t_ subtilis_exp_t;

--- a/ir.h
+++ b/ir.h
@@ -39,41 +39,324 @@ typedef enum {
 } subtilis_op_type_t;
 
 typedef enum {
+	/*
+	 * addi32 r0, r1, r2
+	 *
+	 * Adds two 32 bit signed integers stored in registers and stores the
+	 * result in another register.
+	 *
+	 * r0 = r1 + r2
+	 */
 	SUBTILIS_OP_INSTR_ADD_I32,
+
+	/*
+	 * addr fp0, fp1, fp2
+	 *
+	 * Adds two 64 bit doubles stored in floating point registers and stores
+	 * the result in a third floating point register.
+	 *
+	 * fp0 = fp1 + fp2
+	 */
 	SUBTILIS_OP_INSTR_ADD_REAL,
-	SUBTILIS_OP_INSTR_ADD_STR,
+
+	/*
+	 * subi32 r0, r1, r2
+	 *
+	 * Subtracts two 32 bit integers stored in registers storing the result
+	 * in a third register.
+	 *
+	 * r0 = r1 - r2
+	 */
+
 	SUBTILIS_OP_INSTR_SUB_I32,
+
+	/*
+	 * subr fp0, fp1, fp2
+	 *
+	 * Subtracts two 64 bit doubles stored in floating pointers registers
+	 * storing the result in a third floating point register.
+	 *
+	 * fp0 = fp1 - fp2
+	 */
 	SUBTILIS_OP_INSTR_SUB_REAL,
+
+	/*
+	 * muli32 r0, r1, r2
+	 *
+	 * Multiples two 32 bit signed integers stored in registers storing the
+	 * result in a third register.
+	 *
+	 * r0 = r1 * r2
+	 */
+
 	SUBTILIS_OP_INSTR_MUL_I32,
+
+	/*
+	 * mulr fp0, fp1, fp2
+	 *
+	 * Multiplies two 64 bit doubles stored in floating point registers
+	 * storing the result in a third floating point register.
+	 *
+	 * fp0 = fp1 * fp2
+	 */
+
 	SUBTILIS_OP_INSTR_MUL_REAL,
+
+	/*
+	 * divi32 r0, r1, r2
+	 *
+	 * Divides two 32 bit signed integers stored in registers storing the
+	 * result in a third register.
+	 *
+	 * r0 = r1 / r2
+	 */
+
 	SUBTILIS_OP_INSTR_DIV_I32,
+
+	/*
+	 * divr fp0, fp1, fp2
+	 *
+	 * Divides two 64 bit doubles stored in floating point registers.
+	 * The result is stored in a third floating point register.
+	 *
+	 * fp0 = fp1 / fp2
+	 */
+
 	SUBTILIS_OP_INSTR_DIV_REAL,
+
+	/*
+	 * addii32 r0, r1, #i32
+	 *
+	 * Adds a 32 bit immediate constant to a 32 bit integer stored
+	 * in a register.  The result is stored in a second register.
+	 *
+	 * r0 = r1 + #i32
+	 */
+
 	SUBTILIS_OP_INSTR_ADDI_I32,
+
+	/*
+	 * addir fp0, fp1, #r
+	 *
+	 * Adds a 64 bit double immediate constant to a 64 bit double
+	 * stored in a floating point register.  The result is stored
+	 * in a second floating point register.
+	 *
+	 * fp0 = fp1 + #r
+	 */
+
 	SUBTILIS_OP_INSTR_ADDI_REAL,
+
+	/*
+	 * subii32 r0, r1, #i32
+	 *
+	 * Subtracts a 32 bit integer immediate constant from a 32 bit
+	 * integer stored in a register.  The result is stored in a second
+	 * register.
+	 *
+	 * r0 = r1 - #i32
+	 */
+
 	SUBTILIS_OP_INSTR_SUBI_I32,
+
+	/*
+	 * subir fp0, fp1, #r
+	 *
+	 * Subtracts a 64 bit double immediate constant from a 64 bit
+	 * double stored in a register.  The result is stored in a second
+	 * register.
+	 *
+	 * fp0 = fp1 - #r
+	 */
+
 	SUBTILIS_OP_INSTR_SUBI_REAL,
+
+	/*
+	 * mulii32 r0, r1, #i32
+	 *
+	 * Multiplies a 32 bit immediate constant by a 32 bit integer
+	 * stored in a register.  The resulting product is stored in
+	 * a another register.
+	 *
+	 * r0 = r1 * #i32
+	 */
+
 	SUBTILIS_OP_INSTR_MULI_I32,
+
+	/*
+	 * mulir fp0, fp1, #r
+	 *
+	 * Multiplies a 64 bit double immediate constant by a 64 bit
+	 * double stored in a register.  The result is placed in a
+	 * second floating point register.
+	 *
+	 * fp0 = fp1 * r
+	 */
+
 	SUBTILIS_OP_INSTR_MULI_REAL,
+
+	/*
+	 * divii32 r0, r1, #i32
+	 *
+	 *- Divides a 32 bit integer stored in a register by a 32 bit
+	 * integer immediate constant.  The result is stored in a second
+	 * register.
+	 *
+	 * r0 = r1 / #i32
+	 */
+
 	SUBTILIS_OP_INSTR_DIVI_I32,
+
+	/*
+	 * divir fp0, fp1, #r
+	 *
+	 * Divides a 64 bit double stored in a register by 64 bit double
+	 * immediate constant.  The result is stored in a second floating
+	 * point register.
+	 *
+	 * fp0 = fp1 / #r
+	 */
+
 	SUBTILIS_OP_INSTR_DIVI_REAL,
-	SUBTILIS_OP_INSTR_LOADI_I32,
-	SUBTILIS_OP_INSTR_LOADI_REAL,
-	SUBTILIS_OP_INSTR_LOADI_STR,
+
+	/*
+	 * loadoi32 r0, r1, #off
+	 *
+	 * Loads a 32 bit integer from a memory location formed by
+	 * the sum of the contents of a register and a constant into another
+	 * register.
+	 *
+	 * r0 = [r1 + #off]
+	 */
+
+	SUBTILIS_OP_INSTR_LOADO_I32,
+
+	/*
+	 * loador fp0, r0, #off
+	 *
+	 * Loads a 64 bit double from a memory location formed by
+	 * the sum of the contents of a register and a constant.stored in a
+	 * register into a floating pointer register.
+	 *
+	 * fp0 = [r0 + #off]
+	 */
+
+	SUBTILIS_OP_INSTR_LOADO_REAL,
+
+	/*
+	 * loadi32 r0, r1
+	 *
+	 * Loads a 32 bit integer from a memory location stored in a
+	 * register into another register.
+	 *
+	 * r0 = [r1]
+	 */
+
 	SUBTILIS_OP_INSTR_LOAD_I32,
+
+	/*
+	 * loadr fp0, [r0]
+	 *
+	 * Loads a 64 bit double from a memory location stored in a
+	 * register into a floating point register.
+	 *
+	 * fp0 = [r0]
+	 */
+
 	SUBTILIS_OP_INSTR_LOAD_REAL,
-	SUBTILIS_OP_INSTR_LOAD_STR,
-	SUBTILIS_OP_INSTR_STOREI_I32,
-	SUBTILIS_OP_INSTR_STOREI_REAL,
-	SUBTILIS_OP_INSTR_STOREI_STR,
+
+	/*
+	 * storeoi32 r0, r1, #off
+	 *
+	 * Stores a 32 bit integer stored in a register into the
+	 * memory location defined by the sum of a register and a constant.
+	 *
+	 * [r1 + #off] = r0
+	 */
+
+	SUBTILIS_OP_INSTR_STOREO_I32,
+
+	/*
+	 * storeor fp0, r1, #off
+	 *
+	 * Stores a 64 bit double stored in a floating point register into
+	 * the  memory location defined by the sum of a register and a constant.
+	 *
+	 * [r1 + off] = fp0
+	 */
+
+	SUBTILIS_OP_INSTR_STOREO_REAL,
+
+	/*
+	 * storei32 r0, r1
+	 *
+	 * Stores a 32 bit integer contained in a register into a
+	 * memory location contained within a second register.
+	 *
+	 * [r1] = r0
+	 */
+
 	SUBTILIS_OP_INSTR_STORE_I32,
+
+	/*
+	 * storer fp0, r1
+	 *
+	 * Stores a 64 bit double  contained in a register into a memory
+	 * location contained within a register.
+	 *
+	 * [r1] = fp0
+	 */
+
 	SUBTILIS_OP_INSTR_STORE_REAL,
-	SUBTILIS_OP_INSTR_STORE_STR,
+
+	/*
+	 * movii32 r0, #i32
+	 *
+	 * Moves a 32 bit integer constant into a register.
+	 *
+	 * r0 = #i32
+	 */
+
+	SUBTILIS_OP_INSTR_MOVI_I32,
+
+	/*
+	 * movir fp0, #r
+	 *
+	 * Moves a 64 bit floating point constant into a floating point
+	 * register.
+	 *
+	 * fp0 = r
+	 */
+
+	SUBTILIS_OP_INSTR_MOV_REAL,
+
+	/*
+	 * mov r0, r1
+	 *
+	 * Moves the contents of one 32 bit integer register into another.
+	 *
+	 * r0 = r1
+	 */
+
+	SUBTILIS_OP_INSTR_MOV,
+
+	/*
+	 * movfp fp0, fp1
+	 *
+	 * Moves the contents of one floating point register into another.
+	 *
+	 * fp0 = fp1
+	 */
+
+	SUBTILIS_OP_INSTR_MOVFP,
 } subtilis_op_instr_type_t;
+
+// TODO: Need a type for pointer offsets.  These may not always
+// be 32bit integers.
 
 union subtilis_ir_operand_t_ {
 	int32_t integer;
 	double real;
-	subtilis_buffer_t str;
 	size_t reg;
 };
 
@@ -111,6 +394,10 @@ size_t subtilis_ir_program_add_instr(subtilis_ir_program_t *p,
 				     subtilis_ir_operand_t op1,
 				     subtilis_ir_operand_t op2,
 				     subtilis_error_t *err);
+size_t subtilis_ir_program_add_instr2(subtilis_ir_program_t *p,
+				      subtilis_op_instr_type_t type,
+				      subtilis_ir_operand_t op1,
+				      subtilis_error_t *err);
 void subtilis_ir_program_add_instr_reg(subtilis_ir_program_t *p,
 				       subtilis_op_instr_type_t type,
 				       subtilis_ir_operand_t op0,


### PR DESCRIPTION
This commit cleans up the IR.

1. String types are no longer part of the IR
2. Instructions for moving immediate values in and out of registers
   have been added.
3. Immediate stores and loads from and into registers are no longer
   supported.
4. All instructions are now documented.
5. The code that dumps the IR has been improved to make it easier
   to distinguish between registers and constants.

Signed-off-by: Mark Ryan <markusdryan@gmail.com>