### PR TITLE
Subtraction, Division and Unary Minus

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ install:
 
 script:
  - CFLAGS="-g -fsanitize=address -fno-omit-frame-pointer -Wall -Werror" make check
- - perl checkpatch.pl --no-tree -f --strict --show-types --ignore NEW_TYPEDEFS --ignore PREFER_KERNEL_TYPES --ignore SPLIT_STRING *.c *.h
+ - perl checkpatch.pl --no-tree -f --strict --show-types --ignore NEW_TYPEDEFS --ignore PREFER_KERNEL_TYPES --ignore SPLIT_STRING --ignore UNNECESSARY_PARENTHESES *.c *.h
  - ./check-format.sh

--- a/GCCMk,fd7
+++ b/GCCMk,fd7
@@ -1,4 +1,5 @@
 Dir <Obey$Dir>
 Set CC gcc
+Set CFLAGS "-g -mlibscl"
 WimpSlot -min 17000k
 make %0

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ DEPS = stream.h lexer.h config.h error.h utils.h keywords.h buffer.h expression.
 OBJ = stream.o lexer.o error.o utils.o keywords.o buffer.o parser.o expression.o ir.o hash_table.o symbol_table.o
 UNIT_OBJS = unit_tests.o lexer_test.o parser_test.o symbol_table_test.o vm.o
 
-CFLAGS ?= -O3 -Wall -Werror
+CFLAGS ?= -O3
+CFLAGS += -Wall -Werror
 
 %.o: %.c $(DEPS)
 	$(CC) -c -o $@ $< $(CFLAGS)

--- a/compiler.c
+++ b/compiler.c
@@ -32,6 +32,7 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
+	subtilis_error_init(&err);
 	subtilis_stream_from_file(&s, argv[1], &err);
 	if (err.type != SUBTILIS_ERROR_OK)
 		goto fail;

--- a/expression.c
+++ b/expression.c
@@ -479,6 +479,46 @@ subtilis_exp_t *subtilis_exp_div(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 	return a1;
 }
 
+subtilis_exp_t *subtilis_exp_unary_minus(subtilis_ir_program_t *p,
+					 subtilis_exp_t *e,
+					 subtilis_error_t *err)
+{
+	size_t reg;
+	subtilis_ir_operand_t operand;
+
+	switch (e->type) {
+	case SUBTILIS_EXP_CONST_INTEGER:
+		e->exp.ir_op.integer = -e->exp.ir_op.integer;
+		break;
+	case SUBTILIS_EXP_INTEGER:
+		operand.integer = 0;
+		reg = subtilis_ir_program_add_instr(
+		    p, SUBTILIS_OP_INSTR_RSUBI_I32, e->exp.ir_op, operand, err);
+		if (err->type != SUBTILIS_ERROR_OK)
+			goto cleanup;
+		e->exp.ir_op.reg = reg;
+		break;
+	case SUBTILIS_EXP_CONST_REAL:
+		e->exp.ir_op.real = -e->exp.ir_op.real;
+		break;
+	case SUBTILIS_EXP_CONST_STRING:
+	case SUBTILIS_EXP_REAL:
+	case SUBTILIS_EXP_STRING:
+	default:
+		subtilis_error_set_bad_expression(err, l->stream->name,
+						  l->line);
+		goto cleanup;
+	}
+
+	return e;
+
+cleanup:
+
+	subtilis_exp_delete(e);
+
+	return NULL;
+}
+
 void subtilis_exp_delete(subtilis_exp_t *e)
 {
 	if (!e)

--- a/expression.c
+++ b/expression.c
@@ -181,6 +181,7 @@ subtilis_exp_t *subtilis_exp_add(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 			    p, SUBTILIS_OP_INSTR_ADD_I32, a1->exp.ir_op,
 			    a2->exp.ir_op, err);
 			a1->exp.ir_op.reg = reg;
+			break;
 		case SUBTILIS_EXP_REAL:
 		case SUBTILIS_EXP_STRING:
 			subtilis_error_set_bad_expression(err, l->stream->name,
@@ -263,6 +264,7 @@ subtilis_exp_t *subtilis_exp_sub(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 			    p, SUBTILIS_OP_INSTR_SUB_I32, a1->exp.ir_op,
 			    a2->exp.ir_op, err);
 			a1->exp.ir_op.reg = reg;
+			break;
 		case SUBTILIS_EXP_REAL:
 		case SUBTILIS_EXP_STRING:
 			subtilis_error_set_bad_expression(err, l->stream->name,
@@ -349,6 +351,7 @@ subtilis_exp_t *subtilis_exp_mul(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 			    p, SUBTILIS_OP_INSTR_MUL_I32, a1->exp.ir_op,
 			    a2->exp.ir_op, err);
 			a1->exp.ir_op.reg = reg;
+			break;
 		case SUBTILIS_EXP_REAL:
 		default:
 			subtilis_error_set_bad_expression(err, l->stream->name,
@@ -451,6 +454,7 @@ subtilis_exp_t *subtilis_exp_div(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 			    p, SUBTILIS_OP_INSTR_DIV_I32, a1->exp.ir_op,
 			    a2->exp.ir_op, err);
 			a1->exp.ir_op.reg = reg;
+			break;
 		case SUBTILIS_EXP_REAL:
 		default:
 			subtilis_error_set_bad_expression(err, l->stream->name,

--- a/expression.h
+++ b/expression.h
@@ -64,6 +64,9 @@ subtilis_exp_t *subtilis_exp_mul(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 				 subtilis_exp_t *a2, subtilis_error_t *err);
 subtilis_exp_t *subtilis_exp_div(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 				 subtilis_exp_t *a2, subtilis_error_t *err);
+subtilis_exp_t *subtilis_exp_unary_minus(subtilis_ir_program_t *p,
+					 subtilis_exp_t *e,
+					 subtilis_error_t *err);
 
 void subtilis_exp_delete(subtilis_exp_t *e);
 

--- a/ir.c
+++ b/ir.c
@@ -235,6 +235,8 @@ static const subtilis_ir_op_desc_t op_dump_fns[] = {
 	{ "mov", prv_dump_reg_reg},          /* SUBTILIS_OP_INSTR_MOV */
 	{ "movfp", prv_dump_reg_reg},        /* SUBTILIS_OP_INSTR_MOVFP */
 	{ "printi32", prv_dump_reg},         /* SUBTILIS_OP_INSTR_PRINT_I32 */
+	{ "rsubii32", prv_dump_reg_reg_i32 },/* SUBTILIS_OP_INSTR_RSUBI_I32 */
+	{ "rsubir", prv_dump_reg_reg_real }, /* SUBTILIS_OP_INSTR_RSUBI_REAL */
 };
 
 /* clang-format on */

--- a/ir.c
+++ b/ir.c
@@ -237,6 +237,8 @@ static const subtilis_ir_op_desc_t op_dump_fns[] = {
 	{ "printi32", prv_dump_reg},         /* SUBTILIS_OP_INSTR_PRINT_I32 */
 	{ "rsubii32", prv_dump_reg_reg_i32 },/* SUBTILIS_OP_INSTR_RSUBI_I32 */
 	{ "rsubir", prv_dump_reg_reg_real }, /* SUBTILIS_OP_INSTR_RSUBI_REAL */
+	{ "rdivii32", prv_dump_reg_reg_i32}, /* SUBTILIS_OP_INSTR_RDIVI_I32 */
+	{ "rdivir", prv_dump_reg_reg_i32},   /* SUBTILIS_OP_INSTR_RDIVI_REAL */
 };
 
 /* clang-format on */

--- a/ir.h
+++ b/ir.h
@@ -362,6 +362,30 @@ typedef enum {
 	 */
 
 	SUBTILIS_OP_INSTR_PRINT_I32,
+
+	/*
+	 * rsubii32 r0, r1, #i32
+	 *
+	 * Subtracts a 32 bit integer stored in a register from a
+	 * 32 bit integer immediate constant.  The result is stored in a second
+	 * register.
+	 *
+	 * r0 = #i32 - r1
+	 */
+
+	SUBTILIS_OP_INSTR_RSUBI_I32,
+
+	/*
+	 * rsubir fp0, fp1, #r
+	 *
+	 * Subtracts a 64 bit double stored in a register from a 64 bit double
+	 * immediate constant.  The result is stored in a second register.
+	 *
+	 * fp0 = #r - fp1
+	 */
+
+	SUBTILIS_OP_INSTR_RSUBI_REAL,
+
 } subtilis_op_instr_type_t;
 
 // TODO: Need a type for pointer offsets.  These may not always

--- a/ir.h
+++ b/ir.h
@@ -386,6 +386,28 @@ typedef enum {
 
 	SUBTILIS_OP_INSTR_RSUBI_REAL,
 
+	/*
+	 * rdivii32 r0, r1, #i32
+	 *
+	 * Divides a 32 bit integer immediate constant by a 32 bit integer
+	 * stored in a register.  The result is stored in a second register.
+	 *
+	 * r0 = #i32 / r1
+	 */
+
+	SUBTILIS_OP_INSTR_RDIVI_I32,
+
+	/*
+	 * rdivir fp0, fp1, #r
+	 *
+	 * Divides a 64 bit double immediate constant by a 64 bit double
+	 * stored in a register.  The result is stored in a second register.
+	 *
+	 * fp0 = #r / fp1
+	 */
+
+	SUBTILIS_OP_INSTR_RDIVI_REAL,
+
 } subtilis_op_instr_type_t;
 
 // TODO: Need a type for pointer offsets.  These may not always

--- a/parser_test.c
+++ b/parser_test.c
@@ -162,6 +162,17 @@ static int prv_test_let(void)
 	return prv_test_wrapper(let_test, prv_check_eval_res, "119\n");
 }
 
+static int prv_test_subtraction(void)
+{
+	const char *sub_test = "LET b% = 100 - 5\n"
+			       "LET c% = 10 - b% -10\n"
+			       "LET d% = c% - 1\n"
+			       "PRINT d%\n";
+
+	printf("parser_subtraction");
+	return prv_test_wrapper(sub_test, prv_check_eval_res, "-96\n");
+}
+
 static int prv_test_print(void)
 {
 	printf("parser_print");
@@ -182,6 +193,7 @@ int parser_test(void)
 	failure |= prv_test_not_keyword();
 	failure |= prv_test_let();
 	failure |= prv_test_print();
+	failure |= prv_test_subtraction();
 
 	return failure;
 }

--- a/parser_test.c
+++ b/parser_test.c
@@ -162,26 +162,45 @@ static int prv_test_let(void)
 	return prv_test_wrapper(let_test, prv_check_eval_res, "119\n");
 }
 
-static int prv_test_subtraction(void)
+struct expression_test_t_ {
+	const char *name;
+	const char *source;
+	const char *result;
+};
+
+typedef struct expression_test_t_ expression_test_t;
+
+/* clang-format off */
+static const expression_test_t expression_tests[] = {
+	{ "parser_subtraction",
+	  "LET b% = 100 - 5\n"
+	  "LET c% = 10 - b% -10\n"
+	  "LET d% = c% - 1\n"
+	  "PRINT d%\n",
+	  "-96\n"},
+	{ "parser_division",
+	  "LET b% = 100 / 5\n"
+	  "LET c% = 1000 / b% / 10\n"
+	  "LET d% = c% / 2\n"
+	  "PRINT d%\n",
+	  "2\n"},
+};
+
+/* clang-format on */
+
+static int prv_test_expressions(void)
 {
-	const char *sub_test = "LET b% = 100 - 5\n"
-			       "LET c% = 10 - b% -10\n"
-			       "LET d% = c% - 1\n"
-			       "PRINT d%\n";
+	size_t i;
+	int retval = 0;
 
-	printf("parser_subtraction");
-	return prv_test_wrapper(sub_test, prv_check_eval_res, "-96\n");
-}
+	for (i = 0; i < sizeof(expression_tests) / sizeof(expression_test_t);
+	     i++) {
+		printf("%s", expression_tests[i].name);
+		retval |= prv_test_wrapper(expression_tests[i].source,
+			prv_check_eval_res, expression_tests[i].result);
+	}
 
-static int prv_test_division(void)
-{
-	const char *sub_test = "LET b% = 100 / 5\n"
-			       "LET c% = 1000 / b% / 10\n"
-			       "LET d% = c% / 2\n"
-			       "PRINT d%\n";
-
-	printf("parser_division");
-	return prv_test_wrapper(sub_test, prv_check_eval_res, "2\n");
+	return retval;
 }
 
 static int prv_test_print(void)
@@ -204,8 +223,7 @@ int parser_test(void)
 	failure |= prv_test_not_keyword();
 	failure |= prv_test_let();
 	failure |= prv_test_print();
-	failure |= prv_test_subtraction();
-	failure |= prv_test_division();
+	failure |= prv_test_expressions();
 
 	return failure;
 }

--- a/parser_test.c
+++ b/parser_test.c
@@ -184,6 +184,12 @@ static const expression_test_t expression_tests[] = {
 	  "LET d% = c% / 2\n"
 	  "PRINT d%\n",
 	  "2\n"},
+	{ "parser_multiplication",
+	  "LET b% = 1 * 10\n"
+	  "LET c% = 10 * b% * 5\n"
+	  "LET d% = c% * 2\n"
+	  "PRINT d%\n",
+	  "1000\n"},
 };
 
 /* clang-format on */
@@ -197,7 +203,8 @@ static int prv_test_expressions(void)
 	     i++) {
 		printf("%s", expression_tests[i].name);
 		retval |= prv_test_wrapper(expression_tests[i].source,
-			prv_check_eval_res, expression_tests[i].result);
+					   prv_check_eval_res,
+					   expression_tests[i].result);
 	}
 
 	return retval;

--- a/parser_test.c
+++ b/parser_test.c
@@ -190,6 +190,12 @@ static const expression_test_t expression_tests[] = {
 	  "LET d% = c% * 2\n"
 	  "PRINT d%\n",
 	  "1000\n"},
+	{ "parser_addition",
+	  "LET b% = &ff + 10\n"
+	  "LET c% = &10 + b% + 5\n"
+	  "LET d% = c% + 2 + b%\n"
+	  "PRINT d%\n",
+	  "553\n"},
 };
 
 /* clang-format on */

--- a/parser_test.c
+++ b/parser_test.c
@@ -196,6 +196,11 @@ static const expression_test_t expression_tests[] = {
 	  "LET d% = c% + 2 + b%\n"
 	  "PRINT d%\n",
 	  "553\n"},
+	{ "nested_expression",
+	  "LET a% = (1 + 1)\n"
+	  "LET b% = ((((10 - a%) -5) * 10))\n"
+	  "PRINT b%",
+	  "30\n"},
 };
 
 /* clang-format on */

--- a/parser_test.c
+++ b/parser_test.c
@@ -201,6 +201,12 @@ static const expression_test_t expression_tests[] = {
 	  "LET b% = ((((10 - a%) -5) * 10))\n"
 	  "PRINT b%",
 	  "30\n"},
+	{ "parser_unary_minus",
+	  "LET b% = -110\n"
+	  "LET c% = -b%\n"
+	  "LET d% = 10 - -(c% - 0)\n"
+	  "PRINT d%\n",
+	  "120\n"},
 };
 
 /* clang-format on */

--- a/parser_test.c
+++ b/parser_test.c
@@ -175,21 +175,21 @@ static const expression_test_t expression_tests[] = {
 	{ "parser_subtraction",
 	  "LET b% = 100 - 5\n"
 	  "LET c% = 10 - b% -10\n"
-	  "LET d% = c% - 1\n"
+	  "LET d% = c% - b% - 1\n"
 	  "PRINT d%\n",
-	  "-96\n"},
+	  "-191\n"},
 	{ "parser_division",
 	  "LET b% = 100 / 5\n"
 	  "LET c% = 1000 / b% / 10\n"
-	  "LET d% = c% / 2\n"
+	  "LET d% = b% / c% / 2\n"
 	  "PRINT d%\n",
 	  "2\n"},
 	{ "parser_multiplication",
 	  "LET b% = 1 * 10\n"
 	  "LET c% = 10 * b% * 5\n"
-	  "LET d% = c% * 2\n"
+	  "LET d% = c% * 2 * b%\n"
 	  "PRINT d%\n",
-	  "1000\n"},
+	  "10000\n"},
 	{ "parser_addition",
 	  "LET b% = &ff + 10\n"
 	  "LET c% = &10 + b% + 5\n"

--- a/parser_test.c
+++ b/parser_test.c
@@ -173,6 +173,17 @@ static int prv_test_subtraction(void)
 	return prv_test_wrapper(sub_test, prv_check_eval_res, "-96\n");
 }
 
+static int prv_test_division(void)
+{
+	const char *sub_test = "LET b% = 100 / 5\n"
+			       "LET c% = 1000 / b% / 10\n"
+			       "LET d% = c% / 2\n"
+			       "PRINT d%\n";
+
+	printf("parser_division");
+	return prv_test_wrapper(sub_test, prv_check_eval_res, "2\n");
+}
+
 static int prv_test_print(void)
 {
 	printf("parser_print");
@@ -194,6 +205,7 @@ int parser_test(void)
 	failure |= prv_test_let();
 	failure |= prv_test_print();
 	failure |= prv_test_subtraction();
+	failure |= prv_test_division();
 
 	return failure;
 }

--- a/vm.c
+++ b/vm.c
@@ -66,6 +66,13 @@ static void prv_subi32(subitlis_vm_t *vm, subtilis_buffer_t *b,
 	    vm->regs[ops[1].integer] - vm->regs[ops[2].integer];
 }
 
+static void prv_muli32(subitlis_vm_t *vm, subtilis_buffer_t *b,
+		       subtilis_ir_operand_t *ops, subtilis_error_t *err)
+{
+	vm->regs[ops[0].reg] =
+	    vm->regs[ops[1].integer] * vm->regs[ops[2].integer];
+}
+
 static void prv_movii32(subitlis_vm_t *vm, subtilis_buffer_t *b,
 			subtilis_ir_operand_t *ops, subtilis_error_t *err)
 {
@@ -114,6 +121,12 @@ static void prv_subii32(subitlis_vm_t *vm, subtilis_buffer_t *b,
 	vm->regs[ops[0].reg] = vm->regs[ops[1].reg] - ops[2].integer;
 }
 
+static void prv_mulii32(subitlis_vm_t *vm, subtilis_buffer_t *b,
+			subtilis_ir_operand_t *ops, subtilis_error_t *err)
+{
+	vm->regs[ops[0].reg] = vm->regs[ops[1].reg] * ops[2].integer;
+}
+
 static void prv_divii32(subitlis_vm_t *vm, subtilis_buffer_t *b,
 			subtilis_ir_operand_t *ops, subtilis_error_t *err)
 {
@@ -153,7 +166,7 @@ static subtilis_vm_op_fn op_execute_fns[] = {
 	NULL,                                /* SUBTILIS_OP_INSTR_ADD_REAL */
 	prv_subi32,                          /* SUBTILIS_OP_INSTR_SUB_I32 */
 	NULL,                                /* SUBTILIS_OP_INSTR_SUB_REAL */
-	NULL,                                /* SUBTILIS_OP_INSTR_MUL_I32 */
+	prv_muli32,                          /* SUBTILIS_OP_INSTR_MUL_I32 */
 	NULL,                                /* SUBTILIS_OP_INSTR_MUL_REAL */
 	prv_divi32,                          /* SUBTILIS_OP_INSTR_DIV_I32 */
 	NULL,                                /* SUBTILIS_OP_INSTR_DIV_REAL */
@@ -161,7 +174,7 @@ static subtilis_vm_op_fn op_execute_fns[] = {
 	NULL,                                /* SUBTILIS_OP_INSTR_ADDI_REAL */
 	prv_subii32,                         /* SUBTILIS_OP_INSTR_SUBI_I32 */
 	NULL,                                /* SUBTILIS_OP_INSTR_SUBI_REAL */
-	NULL,                                /* SUBTILIS_OP_INSTR_MULI_I32 */
+	prv_mulii32,                         /* SUBTILIS_OP_INSTR_MULI_I32 */
 	NULL,                                /* SUBTILIS_OP_INSTR_MULI_REAL */
 	prv_divii32,                         /* SUBTILIS_OP_INSTR_DIVI_I32 */
 	NULL,                                /* SUBTILIS_OP_INSTR_DIVI_REAL */

--- a/vm.c
+++ b/vm.c
@@ -56,6 +56,13 @@ fail:
 typedef void (*subtilis_vm_op_fn)(subitlis_vm_t *, subtilis_buffer_t *,
 				  subtilis_ir_operand_t *, subtilis_error_t *);
 
+static void prv_subi32(subitlis_vm_t *vm, subtilis_buffer_t *b,
+		       subtilis_ir_operand_t *ops, subtilis_error_t *err)
+{
+	vm->regs[ops[0].reg] =
+	    vm->regs[ops[1].integer] - vm->regs[ops[2].integer];
+}
+
 static void prv_movii32(subitlis_vm_t *vm, subtilis_buffer_t *b,
 			subtilis_ir_operand_t *ops, subtilis_error_t *err)
 {
@@ -98,6 +105,18 @@ static void prv_addii32(subitlis_vm_t *vm, subtilis_buffer_t *b,
 	vm->regs[ops[0].reg] = vm->regs[ops[1].integer] + ops[2].integer;
 }
 
+static void prv_subii32(subitlis_vm_t *vm, subtilis_buffer_t *b,
+			subtilis_ir_operand_t *ops, subtilis_error_t *err)
+{
+	vm->regs[ops[0].reg] = vm->regs[ops[1].integer] - ops[2].integer;
+}
+
+static void prv_rsubii32(subitlis_vm_t *vm, subtilis_buffer_t *b,
+			 subtilis_ir_operand_t *ops, subtilis_error_t *err)
+{
+	vm->regs[ops[0].reg] = ops[2].integer - vm->regs[ops[1].integer];
+}
+
 static void prv_printi32(subitlis_vm_t *vm, subtilis_buffer_t *b,
 			 subtilis_ir_operand_t *ops, subtilis_error_t *err)
 {
@@ -111,7 +130,7 @@ static void prv_printi32(subitlis_vm_t *vm, subtilis_buffer_t *b,
 static subtilis_vm_op_fn op_execute_fns[] = {
 	NULL,                                /* SUBTILIS_OP_INSTR_ADD_I32 */
 	NULL,                                /* SUBTILIS_OP_INSTR_ADD_REAL */
-	NULL,                                /* SUBTILIS_OP_INSTR_SUB_I32 */
+	prv_subi32,                          /* SUBTILIS_OP_INSTR_SUB_I32 */
 	NULL,                                /* SUBTILIS_OP_INSTR_SUB_REAL */
 	NULL,                                /* SUBTILIS_OP_INSTR_MUL_I32 */
 	NULL,                                /* SUBTILIS_OP_INSTR_MUL_REAL */
@@ -119,7 +138,7 @@ static subtilis_vm_op_fn op_execute_fns[] = {
 	NULL,                                /* SUBTILIS_OP_INSTR_DIV_REAL */
 	prv_addii32,                         /* SUBTILIS_OP_INSTR_ADDI_I32 */
 	NULL,                                /* SUBTILIS_OP_INSTR_ADDI_REAL */
-	NULL,                                /* SUBTILIS_OP_INSTR_SUBI_I32 */
+	prv_subii32,                         /* SUBTILIS_OP_INSTR_SUBI_I32 */
 	NULL,                                /* SUBTILIS_OP_INSTR_SUBI_REAL */
 	NULL,                                /* SUBTILIS_OP_INSTR_MULI_I32 */
 	NULL,                                /* SUBTILIS_OP_INSTR_MULI_REAL */
@@ -138,6 +157,8 @@ static subtilis_vm_op_fn op_execute_fns[] = {
 	NULL,                                /* SUBTILIS_OP_INSTR_MOV */
 	NULL,                                /* SUBTILIS_OP_INSTR_MOVFP */
 	prv_printi32,                        /* SUBTILIS_OP_INSTR_PRINT_I32 */
+	prv_rsubii32,                        /* SUBTILIS_OP_INSTR_RSUBI_I32 */
+	NULL,                                /* SUBTILIS_OP_INSTR_RSUBI_REAL */
 };
 
 /* clang-format on */

--- a/vm.c
+++ b/vm.c
@@ -59,6 +59,13 @@ fail:
 typedef void (*subtilis_vm_op_fn)(subitlis_vm_t *, subtilis_buffer_t *,
 				  subtilis_ir_operand_t *, subtilis_error_t *);
 
+static void prv_addi32(subitlis_vm_t *vm, subtilis_buffer_t *b,
+		       subtilis_ir_operand_t *ops, subtilis_error_t *err)
+{
+	vm->regs[ops[0].reg] =
+	    vm->regs[ops[1].integer] + vm->regs[ops[2].integer];
+}
+
 static void prv_subi32(subitlis_vm_t *vm, subtilis_buffer_t *b,
 		       subtilis_ir_operand_t *ops, subtilis_error_t *err)
 {
@@ -162,7 +169,7 @@ static void prv_rdivii32(subitlis_vm_t *vm, subtilis_buffer_t *b,
 
 /* clang-format off */
 static subtilis_vm_op_fn op_execute_fns[] = {
-	NULL,                                /* SUBTILIS_OP_INSTR_ADD_I32 */
+	prv_addi32,                          /* SUBTILIS_OP_INSTR_ADD_I32 */
 	NULL,                                /* SUBTILIS_OP_INSTR_ADD_REAL */
 	prv_subi32,                          /* SUBTILIS_OP_INSTR_SUB_I32 */
 	NULL,                                /* SUBTILIS_OP_INSTR_SUB_REAL */

--- a/vm.c
+++ b/vm.c
@@ -25,6 +25,9 @@ subitlis_vm_t *subitlis_vm_new(subtilis_ir_program_t *p,
 {
 	subitlis_vm_t *vm = calloc(sizeof(*vm), 1);
 
+	//	printf("\n");
+	//	subtilis_ir_program_dump(p);
+
 	if (!vm) {
 		subtilis_error_set_oom(err);
 		return NULL;
@@ -96,25 +99,25 @@ static void prv_divi32(subitlis_vm_t *vm, subtilis_buffer_t *b,
 		subtilis_error_set_divide_by_zero(err, "", 0);
 		return;
 	}
-	vm->regs[ops[0].reg] = vm->regs[ops[0].reg] / divisor;
+	vm->regs[ops[0].reg] = vm->regs[ops[1].reg] / divisor;
 }
 
 static void prv_addii32(subitlis_vm_t *vm, subtilis_buffer_t *b,
 			subtilis_ir_operand_t *ops, subtilis_error_t *err)
 {
-	vm->regs[ops[0].reg] = vm->regs[ops[1].integer] + ops[2].integer;
+	vm->regs[ops[0].reg] = vm->regs[ops[1].reg] + ops[2].integer;
 }
 
 static void prv_subii32(subitlis_vm_t *vm, subtilis_buffer_t *b,
 			subtilis_ir_operand_t *ops, subtilis_error_t *err)
 {
-	vm->regs[ops[0].reg] = vm->regs[ops[1].integer] - ops[2].integer;
+	vm->regs[ops[0].reg] = vm->regs[ops[1].reg] - ops[2].integer;
 }
 
-static void prv_rsubii32(subitlis_vm_t *vm, subtilis_buffer_t *b,
-			 subtilis_ir_operand_t *ops, subtilis_error_t *err)
+static void prv_divii32(subitlis_vm_t *vm, subtilis_buffer_t *b,
+			subtilis_ir_operand_t *ops, subtilis_error_t *err)
 {
-	vm->regs[ops[0].reg] = ops[2].integer - vm->regs[ops[1].integer];
+	vm->regs[ops[0].reg] = vm->regs[ops[1].reg] / ops[2].integer;
 }
 
 static void prv_printi32(subitlis_vm_t *vm, subtilis_buffer_t *b,
@@ -124,6 +127,24 @@ static void prv_printi32(subitlis_vm_t *vm, subtilis_buffer_t *b,
 
 	sprintf(buf, "%d\n", vm->regs[ops[0].reg]);
 	subtilis_buffer_append_string(b, buf, err);
+}
+
+static void prv_rsubii32(subitlis_vm_t *vm, subtilis_buffer_t *b,
+			 subtilis_ir_operand_t *ops, subtilis_error_t *err)
+{
+	vm->regs[ops[0].reg] = ops[2].integer - vm->regs[ops[1].reg];
+}
+
+static void prv_rdivii32(subitlis_vm_t *vm, subtilis_buffer_t *b,
+			 subtilis_ir_operand_t *ops, subtilis_error_t *err)
+{
+	int32_t divisor = vm->regs[ops[1].reg];
+
+	if (divisor == 0) {
+		subtilis_error_set_divide_by_zero(err, "", 0);
+		return;
+	}
+	vm->regs[ops[0].reg] = ops[2].integer / divisor;
 }
 
 /* clang-format off */
@@ -142,7 +163,7 @@ static subtilis_vm_op_fn op_execute_fns[] = {
 	NULL,                                /* SUBTILIS_OP_INSTR_SUBI_REAL */
 	NULL,                                /* SUBTILIS_OP_INSTR_MULI_I32 */
 	NULL,                                /* SUBTILIS_OP_INSTR_MULI_REAL */
-	NULL,                                /* SUBTILIS_OP_INSTR_DIVI_I32 */
+	prv_divii32,                         /* SUBTILIS_OP_INSTR_DIVI_I32 */
 	NULL,                                /* SUBTILIS_OP_INSTR_DIVI_REAL */
 	prv_loadoi32,                        /* SUBTILIS_OP_INSTR_LOADO_I32 */
 	NULL,                                /* SUBTILIS_OP_INSTR_LOADO_REAL */
@@ -159,6 +180,8 @@ static subtilis_vm_op_fn op_execute_fns[] = {
 	prv_printi32,                        /* SUBTILIS_OP_INSTR_PRINT_I32 */
 	prv_rsubii32,                        /* SUBTILIS_OP_INSTR_RSUBI_I32 */
 	NULL,                                /* SUBTILIS_OP_INSTR_RSUBI_REAL */
+	prv_rdivii32,                        /* SUBTILIS_OP_INSTR_RDIVI_I32 */
+	NULL,                                /* SUBTILIS_OP_INSTR_RDIVI_REAL */
 };
 
 /* clang-format on */


### PR DESCRIPTION
This PR adds support for subtraction, fixes division and adds the unary minus operator, for integers at least.

Division is integer division and so the code push should really be associated with the DIV keyword and not '/'.  This will get fixed later.

Unary minus only works with integers for now.
