### PR TITLE
Refactor the code that handles commutative expressions

### DIFF
--- a/expression.c
+++ b/expression.c
@@ -21,6 +21,19 @@
 /* Swap the arguments if necessary to ensure that the constant comes last
  * Returns true if arguments have been swapped.
  */
+
+typedef void (*subtilis_const_op_t)(subtilis_exp_t *, subtilis_exp_t *);
+
+struct subtilis_commutative_exp_t_ {
+	subtilis_const_op_t op_int_int;
+	subtilis_const_op_t op_int_real;
+	subtilis_const_op_t op_real_real;
+	subtilis_op_instr_type_t in_var_imm;
+	subtilis_op_instr_type_t in_var_var;
+};
+
+typedef struct subtilis_commutative_exp_t_ subtilis_commutative_exp_t;
+
 static bool prv_order_expressions(subtilis_exp_t **a1, subtilis_exp_t **a2)
 {
 	subtilis_exp_t *e1 = *a1;
@@ -291,8 +304,10 @@ subtilis_exp_t *subtilis_exp_sub(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 	return a1;
 }
 
-subtilis_exp_t *subtilis_exp_mul(subtilis_ir_program_t *p, subtilis_exp_t *a1,
-				 subtilis_exp_t *a2, subtilis_error_t *err)
+subtilis_exp_t *subtilis_exp_commutative(subtilis_ir_program_t *p,
+					 subtilis_exp_t *a1, subtilis_exp_t *a2,
+					 subtilis_commutative_exp_t *com,
+					 subtilis_error_t *err)
 {
 	size_t reg;
 
@@ -302,12 +317,10 @@ subtilis_exp_t *subtilis_exp_mul(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 	case SUBTILIS_EXP_CONST_INTEGER:
 		switch (a2->type) {
 		case SUBTILIS_EXP_CONST_INTEGER:
-			a1->exp.ir_op.integer *= a2->exp.ir_op.integer;
+			com->op_int_int(a1, a2);
 			break;
 		case SUBTILIS_EXP_CONST_REAL:
-			a1->exp.ir_op.real = ((double)a1->exp.ir_op.integer) *
-					     a2->exp.ir_op.real;
-			a1->type = SUBTILIS_EXP_CONST_REAL;
+			com->op_int_real(a1, a2);
 			break;
 		default:
 			subtilis_error_set_bad_expression(err, l->stream->name,
@@ -318,10 +331,10 @@ subtilis_exp_t *subtilis_exp_mul(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 	case SUBTILIS_EXP_CONST_REAL:
 		switch (a2->type) {
 		case SUBTILIS_EXP_CONST_INTEGER:
-			a1->exp.ir_op.real *= (double)a2->exp.ir_op.integer;
+			com->op_int_real(a1, a2);
 			break;
 		case SUBTILIS_EXP_CONST_REAL:
-			a1->exp.ir_op.real *= a2->exp.ir_op.real;
+			com->op_real_real(a1, a2);
 			break;
 		default:
 			subtilis_error_set_bad_expression(err, l->stream->name,
@@ -336,9 +349,9 @@ subtilis_exp_t *subtilis_exp_mul(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 	case SUBTILIS_EXP_INTEGER:
 		switch (a2->type) {
 		case SUBTILIS_EXP_CONST_INTEGER:
-			reg = subtilis_ir_program_add_instr(
-			    p, SUBTILIS_OP_INSTR_MULI_I32, a1->exp.ir_op,
-			    a2->exp.ir_op, err);
+			reg = subtilis_ir_program_add_instr(p, com->in_var_imm,
+							    a1->exp.ir_op,
+							    a2->exp.ir_op, err);
 			a1->exp.ir_op.reg = reg;
 			break;
 		case SUBTILIS_EXP_CONST_REAL:
@@ -347,9 +360,9 @@ subtilis_exp_t *subtilis_exp_mul(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 							  l->line);
 			break;
 		case SUBTILIS_EXP_INTEGER:
-			reg = subtilis_ir_program_add_instr(
-			    p, SUBTILIS_OP_INSTR_MUL_I32, a1->exp.ir_op,
-			    a2->exp.ir_op, err);
+			reg = subtilis_ir_program_add_instr(p, com->in_var_var,
+							    a1->exp.ir_op,
+							    a2->exp.ir_op, err);
 			a1->exp.ir_op.reg = reg;
 			break;
 		case SUBTILIS_EXP_REAL:
@@ -374,6 +387,37 @@ subtilis_exp_t *subtilis_exp_mul(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 	}
 
 	return a1;
+}
+
+static void prv_mul_int_int(subtilis_exp_t *a1, subtilis_exp_t *a2)
+{
+	a1->exp.ir_op.integer *= a2->exp.ir_op.integer;
+}
+
+static void prv_mul_int_real(subtilis_exp_t *a1, subtilis_exp_t *a2)
+{
+	a1->exp.ir_op.real =
+	    ((double)a1->exp.ir_op.integer) * a2->exp.ir_op.real;
+	a1->type = SUBTILIS_EXP_CONST_REAL;
+}
+
+static void prv_mul_real_real(subtilis_exp_t *a1, subtilis_exp_t *a2)
+{
+	a1->exp.ir_op.real *= a2->exp.ir_op.real;
+}
+
+subtilis_exp_t *subtilis_exp_mul(subtilis_ir_program_t *p, subtilis_exp_t *a1,
+				 subtilis_exp_t *a2, subtilis_error_t *err)
+{
+	subtilis_commutative_exp_t com = {
+	    .op_int_int = prv_mul_int_int,
+	    .op_int_real = prv_mul_int_real,
+	    .op_real_real = prv_mul_real_real,
+	    .in_var_imm = SUBTILIS_OP_INSTR_MULI_I32,
+	    .in_var_var = SUBTILIS_OP_INSTR_MUL_I32,
+	};
+
+	return subtilis_exp_commutative(p, a1, a2, &com, err);
 }
 
 subtilis_exp_t *subtilis_exp_div(subtilis_ir_program_t *p, subtilis_exp_t *a1,
@@ -519,85 +563,36 @@ cleanup:
 	return NULL;
 }
 
+static void prv_and_int_int(subtilis_exp_t *a1, subtilis_exp_t *a2)
+{
+	a1->exp.ir_op.integer &= a2->exp.ir_op.integer;
+}
+
+static void prv_and_int_real(subtilis_exp_t *a1, subtilis_exp_t *a2)
+{
+	a1->exp.ir_op.real =
+	    (double)(a1->exp.ir_op.integer & ((int32_t)a2->exp.ir_op.real));
+	a1->type = SUBTILIS_EXP_CONST_REAL;
+}
+
+static void prv_and_real_real(subtilis_exp_t *a1, subtilis_exp_t *a2)
+{
+	a1->exp.ir_op.real =
+	    (double)((int32_t)a1->exp.ir_op.real & (int32_t)a2->exp.ir_op.real);
+}
+
 subtilis_exp_t *subtilis_exp_and(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 				 subtilis_exp_t *a2, subtilis_error_t *err)
 {
-	size_t reg;
+	subtilis_commutative_exp_t com = {
+	    .op_int_int = prv_and_int_int,
+	    .op_int_real = prv_and_int_real,
+	    .op_real_real = prv_and_real_real,
+	    .in_var_imm = SUBTILIS_OP_INSTR_ANDI_I32,
+	    .in_var_var = SUBTILIS_OP_INSTR_AND_I32,
+	};
 
-	(void)prv_order_expressions(&a1, &a2);
-
-	switch (a1->type) {
-	case SUBTILIS_EXP_CONST_INTEGER:
-		switch (a2->type) {
-		case SUBTILIS_EXP_CONST_INTEGER:
-			a1->exp.ir_op.integer &= a2->exp.ir_op.integer;
-			break;
-		case SUBTILIS_EXP_CONST_REAL:
-			subtilis_error_set_asssertion_failed(err);
-			break;
-		case SUBTILIS_EXP_CONST_STRING:
-			subtilis_error_set_bad_expression(err, l->stream->name,
-							  l->line);
-			break;
-		default:
-			subtilis_error_set_asssertion_failed(err);
-			break;
-		}
-		break;
-	case SUBTILIS_EXP_CONST_REAL:
-		switch (a2->type) {
-		default:
-			subtilis_error_set_asssertion_failed(err);
-			break;
-		}
-		break;
-	case SUBTILIS_EXP_CONST_STRING:
-		subtilis_error_set_bad_expression(err, l->stream->name,
-						  l->line);
-		break;
-	case SUBTILIS_EXP_INTEGER:
-		switch (a2->type) {
-		case SUBTILIS_EXP_CONST_INTEGER:
-			reg = subtilis_ir_program_add_instr(
-			    p, SUBTILIS_OP_INSTR_ANDI_I32, a1->exp.ir_op,
-			    a2->exp.ir_op, err);
-			a1->exp.ir_op.reg = reg;
-			break;
-		case SUBTILIS_EXP_CONST_REAL:
-		case SUBTILIS_EXP_CONST_STRING:
-			subtilis_error_set_bad_expression(err, l->stream->name,
-							  l->line);
-			break;
-		case SUBTILIS_EXP_INTEGER:
-			reg = subtilis_ir_program_add_instr(
-			    p, SUBTILIS_OP_INSTR_AND_I32, a1->exp.ir_op,
-			    a2->exp.ir_op, err);
-			a1->exp.ir_op.reg = reg;
-			break;
-		case SUBTILIS_EXP_REAL:
-		case SUBTILIS_EXP_STRING:
-			subtilis_error_set_bad_expression(err, l->stream->name,
-							  l->line);
-			break;
-		default:
-			subtilis_error_set_asssertion_failed(err);
-			break;
-		}
-		break;
-	case SUBTILIS_EXP_REAL:
-	case SUBTILIS_EXP_STRING:
-	default:
-		subtilis_error_set_asssertion_failed(err);
-		break;
-	}
-
-	subtilis_exp_delete(a2);
-	if (err->type != SUBTILIS_ERROR_OK) {
-		subtilis_exp_delete(a1);
-		a1 = NULL;
-	}
-
-	return a1;
+	return subtilis_exp_commutative(p, a1, a2, &com, err);
 }
 
 void subtilis_exp_delete(subtilis_exp_t *e)

--- a/expression.c
+++ b/expression.c
@@ -53,6 +53,92 @@ static bool prv_order_expressions(subtilis_exp_t **a1, subtilis_exp_t **a2)
 	return false;
 }
 
+static subtilis_exp_t *prv_exp_commutative(subtilis_ir_program_t *p,
+					   subtilis_exp_t *a1,
+					   subtilis_exp_t *a2,
+					   subtilis_commutative_exp_t *com,
+					   subtilis_error_t *err)
+{
+	size_t reg;
+
+	(void)prv_order_expressions(&a1, &a2);
+
+	switch (a1->type) {
+	case SUBTILIS_EXP_CONST_INTEGER:
+		switch (a2->type) {
+		case SUBTILIS_EXP_CONST_INTEGER:
+			com->op_int_int(a1, a2);
+			break;
+		case SUBTILIS_EXP_CONST_REAL:
+			com->op_int_real(a1, a2);
+			break;
+		default:
+			subtilis_error_set_bad_expression(err, l->stream->name,
+							  l->line);
+			break;
+		}
+		break;
+	case SUBTILIS_EXP_CONST_REAL:
+		switch (a2->type) {
+		case SUBTILIS_EXP_CONST_INTEGER:
+			com->op_int_real(a1, a2);
+			break;
+		case SUBTILIS_EXP_CONST_REAL:
+			com->op_real_real(a1, a2);
+			break;
+		default:
+			subtilis_error_set_bad_expression(err, l->stream->name,
+							  l->line);
+			break;
+		}
+		break;
+	case SUBTILIS_EXP_CONST_STRING:
+		subtilis_error_set_bad_expression(err, l->stream->name,
+						  l->line);
+		break;
+	case SUBTILIS_EXP_INTEGER:
+		switch (a2->type) {
+		case SUBTILIS_EXP_CONST_INTEGER:
+			reg = subtilis_ir_program_add_instr(p, com->in_var_imm,
+							    a1->exp.ir_op,
+							    a2->exp.ir_op, err);
+			a1->exp.ir_op.reg = reg;
+			break;
+		case SUBTILIS_EXP_CONST_REAL:
+		case SUBTILIS_EXP_CONST_STRING:
+			subtilis_error_set_bad_expression(err, l->stream->name,
+							  l->line);
+			break;
+		case SUBTILIS_EXP_INTEGER:
+			reg = subtilis_ir_program_add_instr(p, com->in_var_var,
+							    a1->exp.ir_op,
+							    a2->exp.ir_op, err);
+			a1->exp.ir_op.reg = reg;
+			break;
+		case SUBTILIS_EXP_REAL:
+		default:
+			subtilis_error_set_bad_expression(err, l->stream->name,
+							  l->line);
+			break;
+		}
+		break;
+	case SUBTILIS_EXP_REAL:
+	case SUBTILIS_EXP_STRING:
+	default:
+		subtilis_error_set_bad_expression(err, l->stream->name,
+						  l->line);
+		break;
+	}
+
+	subtilis_exp_delete(a2);
+	if (err->type != SUBTILIS_ERROR_OK) {
+		subtilis_exp_delete(a1);
+		a1 = NULL;
+	}
+
+	return a1;
+}
+
 subtilis_exp_t *subtilis_exp_new_var(subtilis_exp_type_t type, unsigned int reg,
 				     subtilis_error_t *err)
 {
@@ -113,112 +199,68 @@ subtilis_exp_t *subtilis_exp_new_str(subtilis_buffer_t *str,
 	return e;
 }
 
-subtilis_exp_t *subtilis_exp_add(subtilis_ir_program_t *p, subtilis_exp_t *a1,
-				 subtilis_exp_t *a2, subtilis_error_t *err)
+static void prv_add_int_int(subtilis_exp_t *a1, subtilis_exp_t *a2)
+{
+	a1->exp.ir_op.integer += a2->exp.ir_op.integer;
+}
+
+static void prv_add_int_real(subtilis_exp_t *a1, subtilis_exp_t *a2)
+{
+	a1->exp.ir_op.real =
+	    ((double)a1->exp.ir_op.integer) + a2->exp.ir_op.real;
+	a1->type = SUBTILIS_EXP_CONST_REAL;
+}
+
+static void prv_add_real_real(subtilis_exp_t *a1, subtilis_exp_t *a2)
+{
+	a1->exp.ir_op.real += a2->exp.ir_op.real;
+}
+
+static subtilis_exp_t *prv_subtilis_exp_add_str(subtilis_ir_program_t *p,
+						subtilis_exp_t *a1,
+						subtilis_exp_t *a2,
+						subtilis_error_t *err)
 {
 	size_t len;
-	size_t reg;
 
 	(void)prv_order_expressions(&a1, &a2);
 
-	switch (a1->type) {
-	case SUBTILIS_EXP_CONST_INTEGER:
-		switch (a2->type) {
-		case SUBTILIS_EXP_CONST_INTEGER:
-			a1->exp.ir_op.integer += a2->exp.ir_op.integer;
-			break;
-		case SUBTILIS_EXP_CONST_REAL:
-			a1->exp.ir_op.real = ((double)a1->exp.ir_op.integer) +
-					     a2->exp.ir_op.real;
-			a1->type = SUBTILIS_EXP_CONST_REAL;
-			break;
-		case SUBTILIS_EXP_CONST_STRING:
-			subtilis_error_set_bad_expression(err, l->stream->name,
-							  l->line);
-			break;
-		default:
-			subtilis_error_set_asssertion_failed(err);
-			break;
-		}
-		break;
-	case SUBTILIS_EXP_CONST_REAL:
-		switch (a2->type) {
-		case SUBTILIS_EXP_CONST_INTEGER:
-			a1->exp.ir_op.real += (double)a2->exp.ir_op.integer;
-			break;
-		case SUBTILIS_EXP_CONST_REAL:
-			a1->exp.ir_op.real += a2->exp.ir_op.real;
-			break;
-		case SUBTILIS_EXP_CONST_STRING:
-			subtilis_error_set_bad_expression(err, l->stream->name,
-							  l->line);
-			break;
-		default:
-			subtilis_error_set_asssertion_failed(err);
-			break;
-		}
-		break;
-	case SUBTILIS_EXP_CONST_STRING:
-		switch (a2->type) {
-		case SUBTILIS_EXP_CONST_INTEGER:
-		case SUBTILIS_EXP_CONST_REAL:
-			subtilis_error_set_bad_expression(err, l->stream->name,
-							  l->line);
-			break;
-		case SUBTILIS_EXP_CONST_STRING:
-			len = subtilis_buffer_get_size(&a2->exp.str);
-			subtilis_buffer_remove_terminator(&a1->exp.str);
-			subtilis_buffer_append(
-			    &a1->exp.str, a2->exp.str.buffer->data, len, err);
-			break;
-		default:
-			subtilis_error_set_asssertion_failed(err);
-			break;
-		}
-		break;
-	case SUBTILIS_EXP_INTEGER:
-		switch (a2->type) {
-		case SUBTILIS_EXP_CONST_INTEGER:
-			reg = subtilis_ir_program_add_instr(
-			    p, SUBTILIS_OP_INSTR_ADDI_I32, a1->exp.ir_op,
-			    a2->exp.ir_op, err);
-			a1->exp.ir_op.reg = reg;
-			break;
-		case SUBTILIS_EXP_CONST_REAL:
-		case SUBTILIS_EXP_CONST_STRING:
-			subtilis_error_set_bad_expression(err, l->stream->name,
-							  l->line);
-			break;
-		case SUBTILIS_EXP_INTEGER:
-			reg = subtilis_ir_program_add_instr(
-			    p, SUBTILIS_OP_INSTR_ADD_I32, a1->exp.ir_op,
-			    a2->exp.ir_op, err);
-			a1->exp.ir_op.reg = reg;
-			break;
-		case SUBTILIS_EXP_REAL:
-		case SUBTILIS_EXP_STRING:
-			subtilis_error_set_bad_expression(err, l->stream->name,
-							  l->line);
-			break;
-		default:
-			subtilis_error_set_asssertion_failed(err);
-			break;
-		}
-		break;
-	case SUBTILIS_EXP_REAL:
-	case SUBTILIS_EXP_STRING:
-	default:
+	if (a1->type == SUBTILIS_EXP_CONST_STRING) {
+		len = subtilis_buffer_get_size(&a2->exp.str);
+		subtilis_buffer_remove_terminator(&a1->exp.str);
+		subtilis_buffer_append(&a1->exp.str, a2->exp.str.buffer->data,
+				       len, err);
+		if (err->type != SUBTILIS_ERROR_OK)
+			return NULL;
+		return a1;
+	} else if (a2->type == SUBTILIS_EXP_CONST_STRING) {
 		subtilis_error_set_asssertion_failed(err);
-		break;
+		return NULL;
 	}
 
-	subtilis_exp_delete(a2);
-	if (err->type != SUBTILIS_ERROR_OK) {
-		subtilis_exp_delete(a1);
-		a1 = NULL;
+	subtilis_error_set_asssertion_failed(err);
+	return NULL;
+}
+
+subtilis_exp_t *subtilis_exp_add(subtilis_ir_program_t *p, subtilis_exp_t *a1,
+				 subtilis_exp_t *a2, subtilis_error_t *err)
+{
+	subtilis_commutative_exp_t com = {
+	    .op_int_int = prv_add_int_int,
+	    .op_int_real = prv_add_int_real,
+	    .op_real_real = prv_add_real_real,
+	    .in_var_imm = SUBTILIS_OP_INSTR_ADDI_I32,
+	    .in_var_var = SUBTILIS_OP_INSTR_ADD_I32,
+	};
+
+	if ((a1->type == SUBTILIS_EXP_CONST_STRING ||
+	     a1->type == SUBTILIS_EXP_STRING) &&
+	    (a2->type == SUBTILIS_EXP_CONST_STRING ||
+	     a2->type == SUBTILIS_EXP_STRING)) {
+		return prv_subtilis_exp_add_str(p, a1, a2, err);
 	}
 
-	return a1;
+	return prv_exp_commutative(p, a1, a2, &com, err);
 }
 
 subtilis_exp_t *subtilis_exp_sub(subtilis_ir_program_t *p, subtilis_exp_t *a1,
@@ -304,91 +346,6 @@ subtilis_exp_t *subtilis_exp_sub(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 	return a1;
 }
 
-subtilis_exp_t *subtilis_exp_commutative(subtilis_ir_program_t *p,
-					 subtilis_exp_t *a1, subtilis_exp_t *a2,
-					 subtilis_commutative_exp_t *com,
-					 subtilis_error_t *err)
-{
-	size_t reg;
-
-	(void)prv_order_expressions(&a1, &a2);
-
-	switch (a1->type) {
-	case SUBTILIS_EXP_CONST_INTEGER:
-		switch (a2->type) {
-		case SUBTILIS_EXP_CONST_INTEGER:
-			com->op_int_int(a1, a2);
-			break;
-		case SUBTILIS_EXP_CONST_REAL:
-			com->op_int_real(a1, a2);
-			break;
-		default:
-			subtilis_error_set_bad_expression(err, l->stream->name,
-							  l->line);
-			break;
-		}
-		break;
-	case SUBTILIS_EXP_CONST_REAL:
-		switch (a2->type) {
-		case SUBTILIS_EXP_CONST_INTEGER:
-			com->op_int_real(a1, a2);
-			break;
-		case SUBTILIS_EXP_CONST_REAL:
-			com->op_real_real(a1, a2);
-			break;
-		default:
-			subtilis_error_set_bad_expression(err, l->stream->name,
-							  l->line);
-			break;
-		}
-		break;
-	case SUBTILIS_EXP_CONST_STRING:
-		subtilis_error_set_bad_expression(err, l->stream->name,
-						  l->line);
-		break;
-	case SUBTILIS_EXP_INTEGER:
-		switch (a2->type) {
-		case SUBTILIS_EXP_CONST_INTEGER:
-			reg = subtilis_ir_program_add_instr(p, com->in_var_imm,
-							    a1->exp.ir_op,
-							    a2->exp.ir_op, err);
-			a1->exp.ir_op.reg = reg;
-			break;
-		case SUBTILIS_EXP_CONST_REAL:
-		case SUBTILIS_EXP_CONST_STRING:
-			subtilis_error_set_bad_expression(err, l->stream->name,
-							  l->line);
-			break;
-		case SUBTILIS_EXP_INTEGER:
-			reg = subtilis_ir_program_add_instr(p, com->in_var_var,
-							    a1->exp.ir_op,
-							    a2->exp.ir_op, err);
-			a1->exp.ir_op.reg = reg;
-			break;
-		case SUBTILIS_EXP_REAL:
-		default:
-			subtilis_error_set_bad_expression(err, l->stream->name,
-							  l->line);
-			break;
-		}
-		break;
-	case SUBTILIS_EXP_REAL:
-	case SUBTILIS_EXP_STRING:
-	default:
-		subtilis_error_set_bad_expression(err, l->stream->name,
-						  l->line);
-		break;
-	}
-
-	subtilis_exp_delete(a2);
-	if (err->type != SUBTILIS_ERROR_OK) {
-		subtilis_exp_delete(a1);
-		a1 = NULL;
-	}
-
-	return a1;
-}
-
 static void prv_mul_int_int(subtilis_exp_t *a1, subtilis_exp_t *a2)
 {
 	a1->exp.ir_op.integer *= a2->exp.ir_op.integer;
@@ -417,7 +374,7 @@ subtilis_exp_t *subtilis_exp_mul(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 	    .in_var_var = SUBTILIS_OP_INSTR_MUL_I32,
 	};
 
-	return subtilis_exp_commutative(p, a1, a2, &com, err);
+	return prv_exp_commutative(p, a1, a2, &com, err);
 }
 
 subtilis_exp_t *subtilis_exp_div(subtilis_ir_program_t *p, subtilis_exp_t *a1,
@@ -592,7 +549,7 @@ subtilis_exp_t *subtilis_exp_and(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 	    .in_var_var = SUBTILIS_OP_INSTR_AND_I32,
 	};
 
-	return subtilis_exp_commutative(p, a1, a2, &com, err);
+	return prv_exp_commutative(p, a1, a2, &com, err);
 }
 
 void subtilis_exp_delete(subtilis_exp_t *e)


### PR DESCRIPTION
This is done to avoid a huge amount of code duplication before adding the logical operators.