### PR TITLE
Allow hex and binary numbers greater than 2147483647

### DIFF
--- a/lexer.c
+++ b/lexer.c
@@ -273,7 +273,7 @@ static void prv_process_float(subtilis_lexer_t *l, subtilis_token_t *t,
 	t->tok.real = atof(tbuf);
 }
 
-/* TODO:  Need to figure out if maximum negative int constant is correct */
+/* TODO:  The maximum negative int constant is incorrect */
 
 static void prv_parse_integer(subtilis_lexer_t *l, subtilis_token_t *t,
 			      int base, subtilis_error_t *err)
@@ -288,11 +288,17 @@ static void prv_parse_integer(subtilis_lexer_t *l, subtilis_token_t *t,
 
 	errno = 0;
 	num = strtoul(tbuf, &end_ptr, base);
-	if (*end_ptr != 0 || errno != 0 || num > 2147483647) {
+	if (*end_ptr != 0 || errno != 0) {
 		subtilis_error_set_number_too_long(err, tbuf, l->stream->name,
 						   l->line);
 		return;
 	}
+	if ((base == 10 && num > 2147483647) || (num > 0xffffffff)) {
+		subtilis_error_set_number_too_long(err, tbuf, l->stream->name,
+						   l->line);
+		return;
+	}
+
 	t->tok.integer = (int32_t)num;
 }
 

--- a/lexer_test.c
+++ b/lexer_test.c
@@ -595,9 +595,8 @@ static int prv_check_int(subtilis_lexer_t *l, subtilis_token_t *t)
 	int i;
 	const char *tbuf;
 
-	const int expected[] = {
-	    12345, 67890, 0x12345, 0x67890, 0xabcef, 2147483647, 170,
-	};
+	const int expected[] = {12345,   67890,      0x12345, 0x67890,
+				0xabcef, 2147483647, 170,     0xffffffff};
 
 	const int expected_signed[] = {255, 0xff, 255};
 
@@ -663,8 +662,8 @@ static int prv_test_int(void)
 {
 	size_t i;
 	int res = 0;
-	const char *str = "12345 67890 &12345 &67890 &abcef 2147483647"
-			  "%10101010 -255 -&ff -%11111111";
+	const char *str = "12345 67890 &12345 &67890 &abcef 2147483647 "
+			  "%10101010 &ffffffff -255 -&ff -%11111111";
 
 	printf("lexer_int");
 	for (i = 0; i < sizeof(buffer_sizes) / sizeof(size_t); i++)
@@ -995,6 +994,9 @@ static int prv_test_number_too_large(void)
 
 	for (i = 0; i < sizeof(buffer_sizes) / sizeof(size_t); i++)
 		res |= prv_test_wrapper("2147483648", buffer_sizes[i],
+					prv_check_number_too_large);
+	for (i = 0; i < sizeof(buffer_sizes) / sizeof(size_t); i++)
+		res |= prv_test_wrapper("&100000000", buffer_sizes[i],
 					prv_check_number_too_large);
 	printf(": [%s]\n", res ? "FAIL" : "OK");
 


### PR DESCRIPTION
It was previously impossible to specify &ffffffff as an integer
constant.  This now works although it's not perfect as
-2147483648 is not currently allowed when it should be.

Signed-off-by: Mark Ryan <markusdryan@gmail.com>