### PR TITLE
Implement = and <> and fix locale issues

### DIFF
--- a/compiler.c
+++ b/compiler.c
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <locale.h>
 #include <stdio.h>
 
 #include "error.h"
@@ -31,6 +32,8 @@ int main(int argc, char *argv[])
 		fprintf(stderr, "Usage: basicc file\n");
 		return 1;
 	}
+
+	setlocale(LC_ALL, "C");
 
 	subtilis_error_init(&err);
 	subtilis_stream_from_file(&s, argv[1], &err);

--- a/error.h
+++ b/error.h
@@ -103,35 +103,27 @@ void subtilis_error_init(subtilis_error_t *e);
 	subtilis_error_set_basic(e, SUBTILIS_ERROR_ASSERTION_FAILED, __FILE__, \
 				 __LINE__)
 #define subtilis_error_set_keyword_expected(e, str, file, line)                \
-	subtilis_error_set1(e, SUBTILIS_ERROR_KEYWORD_EXPECTED, str, __FILE__, \
-			    __LINE__)
+	subtilis_error_set1(e, SUBTILIS_ERROR_KEYWORD_EXPECTED, str, file, line)
 #define subtilis_error_set_not_supported(e, str, file, line)                   \
-	subtilis_error_set1(e, SUBTILIS_ERROR_NOT_SUPPORTED, str, __FILE__,    \
-			    __LINE__)
+	subtilis_error_set1(e, SUBTILIS_ERROR_NOT_SUPPORTED, str, file, line)
 #define subtilis_error_set_id_expected(e, str, file, line)                     \
-	subtilis_error_set1(e, SUBTILIS_ERROR_ID_EXPECTED, str, __FILE__,      \
-			    __LINE__)
+	subtilis_error_set1(e, SUBTILIS_ERROR_ID_EXPECTED, str, file, line)
 #define subtilis_error_set_assignment_op_expected(e, str, file, line)          \
 	subtilis_error_set1(e, SUBTILIS_ERROR_ASSIGNMENT_OP_EXPECTED, str,     \
-			    __FILE__, __LINE__)
+			    file, line)
 #define subtilis_error_set_exp_expected(e, str, file, line)                    \
-	subtilis_error_set1(e, SUBTILIS_ERROR_EXP_EXPECTED, str, __FILE__,     \
-			    __LINE__)
+	subtilis_error_set1(e, SUBTILIS_ERROR_EXP_EXPECTED, str, file, line)
 #define subtilis_error_set_right_bkt_expected(e, str, file, line)              \
-	subtilis_error_set1(e, SUBTILIS_ERROR_RIGHT_BKT_EXPECTED, str,         \
-			    __FILE__, __LINE__)
+	subtilis_error_set1(e, SUBTILIS_ERROR_RIGHT_BKT_EXPECTED, str, file,   \
+			    line)
 #define subtilis_error_set_integer_expected(e, str, file, line)                \
-	subtilis_error_set1(e, SUBTILIS_ERROR_INTEGER_EXPECTED, str, __FILE__, \
-			    __LINE__)
+	subtilis_error_set1(e, SUBTILIS_ERROR_INTEGER_EXPECTED, str, file, line)
 #define subtilis_error_set_bad_expression(e, file, line)                       \
-	subtilis_error_set_basic(e, SUBTILIS_ERROR_BAD_EXPRESSION, __FILE__,   \
-				 __LINE__)
+	subtilis_error_set_basic(e, SUBTILIS_ERROR_BAD_EXPRESSION, file, line)
 #define subtilis_error_set_divide_by_zero(e, file, line)                       \
-	subtilis_error_set_basic(e, SUBTILIS_ERROR_DIVIDE_BY_ZERO, __FILE__,   \
-				 __LINE__)
+	subtilis_error_set_basic(e, SUBTILIS_ERROR_DIVIDE_BY_ZERO, file, line)
 #define subtilis_error_set_unknown_variable(e, str, file, line)                \
-	subtilis_error_set1(e, SUBTILIS_ERROR_UNKNOWN_VARIABLE, str, __FILE__, \
-			    __LINE__)
+	subtilis_error_set1(e, SUBTILIS_ERROR_UNKNOWN_VARIABLE, str, file, line)
 
 void subtilis_error_set_full(subtilis_error_t *e, subtilis_error_type_t type,
 			     const char *data1, const char *data2,

--- a/expression.c
+++ b/expression.c
@@ -53,7 +53,7 @@ static bool prv_order_expressions(subtilis_exp_t **a1, subtilis_exp_t **a2)
 	return false;
 }
 
-static subtilis_exp_t *prv_exp_commutative(subtilis_ir_program_t *p,
+static subtilis_exp_t *prv_exp_commutative(subtilis_parser_t *p,
 					   subtilis_exp_t *a1,
 					   subtilis_exp_t *a2,
 					   subtilis_commutative_exp_t *com,
@@ -73,8 +73,8 @@ static subtilis_exp_t *prv_exp_commutative(subtilis_ir_program_t *p,
 			com->op_int_real(a1, a2);
 			break;
 		default:
-			subtilis_error_set_bad_expression(err, l->stream->name,
-							  l->line);
+			subtilis_error_set_bad_expression(
+			    err, p->l->stream->name, p->l->line);
 			break;
 		}
 		break;
@@ -87,46 +87,46 @@ static subtilis_exp_t *prv_exp_commutative(subtilis_ir_program_t *p,
 			com->op_real_real(a1, a2);
 			break;
 		default:
-			subtilis_error_set_bad_expression(err, l->stream->name,
-							  l->line);
+			subtilis_error_set_bad_expression(
+			    err, p->l->stream->name, p->l->line);
 			break;
 		}
 		break;
 	case SUBTILIS_EXP_CONST_STRING:
-		subtilis_error_set_bad_expression(err, l->stream->name,
-						  l->line);
+		subtilis_error_set_bad_expression(err, p->l->stream->name,
+						  p->l->line);
 		break;
 	case SUBTILIS_EXP_INTEGER:
 		switch (a2->type) {
 		case SUBTILIS_EXP_CONST_INTEGER:
-			reg = subtilis_ir_program_add_instr(p, com->in_var_imm,
-							    a1->exp.ir_op,
-							    a2->exp.ir_op, err);
+			reg = subtilis_ir_program_add_instr(
+			    p->p, com->in_var_imm, a1->exp.ir_op, a2->exp.ir_op,
+			    err);
 			a1->exp.ir_op.reg = reg;
 			break;
 		case SUBTILIS_EXP_CONST_REAL:
 		case SUBTILIS_EXP_CONST_STRING:
-			subtilis_error_set_bad_expression(err, l->stream->name,
-							  l->line);
+			subtilis_error_set_bad_expression(
+			    err, p->l->stream->name, p->l->line);
 			break;
 		case SUBTILIS_EXP_INTEGER:
-			reg = subtilis_ir_program_add_instr(p, com->in_var_var,
-							    a1->exp.ir_op,
-							    a2->exp.ir_op, err);
+			reg = subtilis_ir_program_add_instr(
+			    p->p, com->in_var_var, a1->exp.ir_op, a2->exp.ir_op,
+			    err);
 			a1->exp.ir_op.reg = reg;
 			break;
 		case SUBTILIS_EXP_REAL:
 		default:
-			subtilis_error_set_bad_expression(err, l->stream->name,
-							  l->line);
+			subtilis_error_set_bad_expression(
+			    err, p->l->stream->name, p->l->line);
 			break;
 		}
 		break;
 	case SUBTILIS_EXP_REAL:
 	case SUBTILIS_EXP_STRING:
 	default:
-		subtilis_error_set_bad_expression(err, l->stream->name,
-						  l->line);
+		subtilis_error_set_bad_expression(err, p->l->stream->name,
+						  p->l->line);
 		break;
 	}
 
@@ -216,7 +216,7 @@ static void prv_add_real_real(subtilis_exp_t *a1, subtilis_exp_t *a2)
 	a1->exp.ir_op.real += a2->exp.ir_op.real;
 }
 
-static subtilis_exp_t *prv_subtilis_exp_add_str(subtilis_ir_program_t *p,
+static subtilis_exp_t *prv_subtilis_exp_add_str(subtilis_parser_t *p,
 						subtilis_exp_t *a1,
 						subtilis_exp_t *a2,
 						subtilis_error_t *err)
@@ -242,7 +242,7 @@ static subtilis_exp_t *prv_subtilis_exp_add_str(subtilis_ir_program_t *p,
 	return NULL;
 }
 
-subtilis_exp_t *subtilis_exp_add(subtilis_ir_program_t *p, subtilis_exp_t *a1,
+subtilis_exp_t *subtilis_exp_add(subtilis_parser_t *p, subtilis_exp_t *a1,
 				 subtilis_exp_t *a2, subtilis_error_t *err)
 {
 	subtilis_commutative_exp_t com = {
@@ -263,7 +263,7 @@ subtilis_exp_t *subtilis_exp_add(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 	return prv_exp_commutative(p, a1, a2, &com, err);
 }
 
-subtilis_exp_t *subtilis_exp_sub(subtilis_ir_program_t *p, subtilis_exp_t *a1,
+subtilis_exp_t *subtilis_exp_sub(subtilis_parser_t *p, subtilis_exp_t *a1,
 				 subtilis_exp_t *a2, subtilis_error_t *err)
 {
 	size_t reg;
@@ -306,24 +306,24 @@ subtilis_exp_t *subtilis_exp_sub(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 			instr = swapped ? SUBTILIS_OP_INSTR_RSUBI_I32
 					: SUBTILIS_OP_INSTR_SUBI_I32;
 			reg = subtilis_ir_program_add_instr(
-			    p, instr, a1->exp.ir_op, a2->exp.ir_op, err);
+			    p->p, instr, a1->exp.ir_op, a2->exp.ir_op, err);
 			a1->exp.ir_op.reg = reg;
 			break;
 		case SUBTILIS_EXP_CONST_REAL:
 		case SUBTILIS_EXP_CONST_STRING:
-			subtilis_error_set_bad_expression(err, l->stream->name,
-							  l->line);
+			subtilis_error_set_bad_expression(
+			    err, p->l->stream->name, p->l->line);
 			break;
 		case SUBTILIS_EXP_INTEGER:
 			reg = subtilis_ir_program_add_instr(
-			    p, SUBTILIS_OP_INSTR_SUB_I32, a1->exp.ir_op,
+			    p->p, SUBTILIS_OP_INSTR_SUB_I32, a1->exp.ir_op,
 			    a2->exp.ir_op, err);
 			a1->exp.ir_op.reg = reg;
 			break;
 		case SUBTILIS_EXP_REAL:
 		case SUBTILIS_EXP_STRING:
-			subtilis_error_set_bad_expression(err, l->stream->name,
-							  l->line);
+			subtilis_error_set_bad_expression(
+			    err, p->l->stream->name, p->l->line);
 			break;
 		default:
 			subtilis_error_set_asssertion_failed(err);
@@ -363,7 +363,7 @@ static void prv_mul_real_real(subtilis_exp_t *a1, subtilis_exp_t *a2)
 	a1->exp.ir_op.real *= a2->exp.ir_op.real;
 }
 
-subtilis_exp_t *subtilis_exp_mul(subtilis_ir_program_t *p, subtilis_exp_t *a1,
+subtilis_exp_t *subtilis_exp_mul(subtilis_parser_t *p, subtilis_exp_t *a1,
 				 subtilis_exp_t *a2, subtilis_error_t *err)
 {
 	subtilis_commutative_exp_t com = {
@@ -377,7 +377,7 @@ subtilis_exp_t *subtilis_exp_mul(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 	return prv_exp_commutative(p, a1, a2, &com, err);
 }
 
-subtilis_exp_t *subtilis_exp_div(subtilis_ir_program_t *p, subtilis_exp_t *a1,
+subtilis_exp_t *subtilis_exp_div(subtilis_parser_t *p, subtilis_exp_t *a1,
 				 subtilis_exp_t *a2, subtilis_error_t *err)
 {
 	size_t reg;
@@ -391,7 +391,7 @@ subtilis_exp_t *subtilis_exp_div(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 		case SUBTILIS_EXP_CONST_INTEGER:
 			if (a2->exp.ir_op.integer == 0) {
 				subtilis_error_set_divide_by_zero(
-				    err, l->stream->name, l->line);
+				    err, p->l->stream->name, p->l->line);
 				break;
 			}
 			a1->exp.ir_op.integer /= a2->exp.ir_op.integer;
@@ -403,8 +403,8 @@ subtilis_exp_t *subtilis_exp_div(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 			a1->type = SUBTILIS_EXP_CONST_REAL;
 			break;
 		default:
-			subtilis_error_set_bad_expression(err, l->stream->name,
-							  l->line);
+			subtilis_error_set_bad_expression(
+			    err, p->l->stream->name, p->l->line);
 			break;
 		}
 		break;
@@ -419,14 +419,14 @@ subtilis_exp_t *subtilis_exp_div(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 			a1->exp.ir_op.real /= a2->exp.ir_op.real;
 			break;
 		default:
-			subtilis_error_set_bad_expression(err, l->stream->name,
-							  l->line);
+			subtilis_error_set_bad_expression(
+			    err, p->l->stream->name, p->l->line);
 			break;
 		}
 		break;
 	case SUBTILIS_EXP_CONST_STRING:
-		subtilis_error_set_bad_expression(err, l->stream->name,
-						  l->line);
+		subtilis_error_set_bad_expression(err, p->l->stream->name,
+						  p->l->line);
 		break;
 	case SUBTILIS_EXP_INTEGER:
 		switch (a2->type) {
@@ -436,38 +436,39 @@ subtilis_exp_t *subtilis_exp_div(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 			} else {
 				if (a2->exp.ir_op.integer == 0) {
 					subtilis_error_set_divide_by_zero(
-					    err, l->stream->name, l->line);
+					    err, p->l->stream->name,
+					    p->l->line);
 					break;
 				}
 				instr = SUBTILIS_OP_INSTR_DIVI_I32;
 			}
 			reg = subtilis_ir_program_add_instr(
-			    p, instr, a1->exp.ir_op, a2->exp.ir_op, err);
+			    p->p, instr, a1->exp.ir_op, a2->exp.ir_op, err);
 			a1->exp.ir_op.reg = reg;
 			break;
 		case SUBTILIS_EXP_CONST_REAL:
 		case SUBTILIS_EXP_CONST_STRING:
-			subtilis_error_set_bad_expression(err, l->stream->name,
-							  l->line);
+			subtilis_error_set_bad_expression(
+			    err, p->l->stream->name, p->l->line);
 			break;
 		case SUBTILIS_EXP_INTEGER:
 			reg = subtilis_ir_program_add_instr(
-			    p, SUBTILIS_OP_INSTR_DIV_I32, a1->exp.ir_op,
+			    p->p, SUBTILIS_OP_INSTR_DIV_I32, a1->exp.ir_op,
 			    a2->exp.ir_op, err);
 			a1->exp.ir_op.reg = reg;
 			break;
 		case SUBTILIS_EXP_REAL:
 		default:
-			subtilis_error_set_bad_expression(err, l->stream->name,
-							  l->line);
+			subtilis_error_set_bad_expression(
+			    err, p->l->stream->name, p->l->line);
 			break;
 		}
 		break;
 	case SUBTILIS_EXP_REAL:
 	case SUBTILIS_EXP_STRING:
 	default:
-		subtilis_error_set_bad_expression(err, l->stream->name,
-						  l->line);
+		subtilis_error_set_bad_expression(err, p->l->stream->name,
+						  p->l->line);
 		break;
 	}
 
@@ -480,7 +481,7 @@ subtilis_exp_t *subtilis_exp_div(subtilis_ir_program_t *p, subtilis_exp_t *a1,
 	return a1;
 }
 
-subtilis_exp_t *subtilis_exp_unary_minus(subtilis_ir_program_t *p,
+subtilis_exp_t *subtilis_exp_unary_minus(subtilis_parser_t *p,
 					 subtilis_exp_t *e,
 					 subtilis_error_t *err)
 {
@@ -493,8 +494,9 @@ subtilis_exp_t *subtilis_exp_unary_minus(subtilis_ir_program_t *p,
 		break;
 	case SUBTILIS_EXP_INTEGER:
 		operand.integer = 0;
-		reg = subtilis_ir_program_add_instr(
-		    p, SUBTILIS_OP_INSTR_RSUBI_I32, e->exp.ir_op, operand, err);
+		reg = subtilis_ir_program_add_instr(p->p,
+						    SUBTILIS_OP_INSTR_RSUBI_I32,
+						    e->exp.ir_op, operand, err);
 		if (err->type != SUBTILIS_ERROR_OK)
 			goto cleanup;
 		e->exp.ir_op.reg = reg;
@@ -506,8 +508,8 @@ subtilis_exp_t *subtilis_exp_unary_minus(subtilis_ir_program_t *p,
 	case SUBTILIS_EXP_REAL:
 	case SUBTILIS_EXP_STRING:
 	default:
-		subtilis_error_set_bad_expression(err, l->stream->name,
-						  l->line);
+		subtilis_error_set_bad_expression(err, p->l->stream->name,
+						  p->l->line);
 		goto cleanup;
 	}
 
@@ -520,7 +522,7 @@ cleanup:
 	return NULL;
 }
 
-subtilis_exp_t *subtilis_exp_not(subtilis_ir_program_t *p, subtilis_exp_t *e,
+subtilis_exp_t *subtilis_exp_not(subtilis_parser_t *p, subtilis_exp_t *e,
 				 subtilis_error_t *err)
 {
 	size_t reg;
@@ -531,7 +533,7 @@ subtilis_exp_t *subtilis_exp_not(subtilis_ir_program_t *p, subtilis_exp_t *e,
 		break;
 	case SUBTILIS_EXP_INTEGER:
 		reg = subtilis_ir_program_add_instr2(
-		    p, SUBTILIS_OP_INSTR_NOT_I32, e->exp.ir_op, err);
+		    p->p, SUBTILIS_OP_INSTR_NOT_I32, e->exp.ir_op, err);
 		if (err->type != SUBTILIS_ERROR_OK)
 			goto cleanup;
 		e->exp.ir_op.reg = reg;
@@ -543,8 +545,8 @@ subtilis_exp_t *subtilis_exp_not(subtilis_ir_program_t *p, subtilis_exp_t *e,
 	case SUBTILIS_EXP_REAL:
 	case SUBTILIS_EXP_STRING:
 	default:
-		subtilis_error_set_bad_expression(err, l->stream->name,
-						  l->line);
+		subtilis_error_set_bad_expression(err, p->l->stream->name,
+						  p->l->line);
 		goto cleanup;
 	}
 
@@ -575,7 +577,7 @@ static void prv_and_real_real(subtilis_exp_t *a1, subtilis_exp_t *a2)
 	    (double)((int32_t)a1->exp.ir_op.real & (int32_t)a2->exp.ir_op.real);
 }
 
-subtilis_exp_t *subtilis_exp_and(subtilis_ir_program_t *p, subtilis_exp_t *a1,
+subtilis_exp_t *subtilis_exp_and(subtilis_parser_t *p, subtilis_exp_t *a1,
 				 subtilis_exp_t *a2, subtilis_error_t *err)
 {
 	subtilis_commutative_exp_t com = {
@@ -607,7 +609,7 @@ static void prv_or_real_real(subtilis_exp_t *a1, subtilis_exp_t *a2)
 	    (double)((int32_t)a1->exp.ir_op.real | (int32_t)a2->exp.ir_op.real);
 }
 
-subtilis_exp_t *subtilis_exp_or(subtilis_ir_program_t *p, subtilis_exp_t *a1,
+subtilis_exp_t *subtilis_exp_or(subtilis_parser_t *p, subtilis_exp_t *a1,
 				subtilis_exp_t *a2, subtilis_error_t *err)
 {
 	subtilis_commutative_exp_t com = {
@@ -639,7 +641,7 @@ static void prv_eor_real_real(subtilis_exp_t *a1, subtilis_exp_t *a2)
 	    (double)((int32_t)a1->exp.ir_op.real ^ (int32_t)a2->exp.ir_op.real);
 }
 
-subtilis_exp_t *subtilis_exp_eor(subtilis_ir_program_t *p, subtilis_exp_t *a1,
+subtilis_exp_t *subtilis_exp_eor(subtilis_parser_t *p, subtilis_exp_t *a1,
 				 subtilis_exp_t *a2, subtilis_error_t *err)
 {
 	subtilis_commutative_exp_t com = {

--- a/expression.c
+++ b/expression.c
@@ -655,6 +655,90 @@ subtilis_exp_t *subtilis_exp_eor(subtilis_parser_t *p, subtilis_exp_t *a1,
 	return prv_exp_commutative(p, a1, a2, &com, err);
 }
 
+static void prv_eq_int_int(subtilis_exp_t *a1, subtilis_exp_t *a2)
+{
+	a1->exp.ir_op.integer =
+	    a1->exp.ir_op.integer == a2->exp.ir_op.integer ? -1 : 0;
+}
+
+static void prv_eq_int_real(subtilis_exp_t *a1, subtilis_exp_t *a2)
+{
+	a1->exp.ir_op.integer =
+	    a1->exp.ir_op.integer == ((int32_t)a2->exp.ir_op.real) ? -1 : 0;
+	a1->type = SUBTILIS_EXP_CONST_INTEGER;
+}
+
+static void prv_eq_real_real(subtilis_exp_t *a1, subtilis_exp_t *a2)
+{
+	a1->exp.ir_op.integer =
+	    a1->exp.ir_op.real == a2->exp.ir_op.real ? -1 : 0;
+	a1->type = SUBTILIS_EXP_CONST_INTEGER;
+}
+
+subtilis_exp_t *subtilis_exp_eq(subtilis_parser_t *p, subtilis_exp_t *a1,
+				subtilis_exp_t *a2, subtilis_error_t *err)
+{
+	subtilis_commutative_exp_t com = {
+	    .op_int_int = prv_eq_int_int,
+	    .op_int_real = prv_eq_int_real,
+	    .op_real_real = prv_eq_real_real,
+	    .in_var_imm = SUBTILIS_OP_INSTR_EQI_I32,
+	    .in_var_var = SUBTILIS_OP_INSTR_EQ_I32,
+	};
+
+	if ((a1->type == SUBTILIS_EXP_CONST_STRING ||
+	     a1->type == SUBTILIS_EXP_STRING) &&
+	    (a2->type == SUBTILIS_EXP_CONST_STRING ||
+	     a2->type == SUBTILIS_EXP_STRING)) {
+		subtilis_error_set_asssertion_failed(err);
+		return NULL;
+	}
+
+	return prv_exp_commutative(p, a1, a2, &com, err);
+}
+
+static void prv_neq_int_int(subtilis_exp_t *a1, subtilis_exp_t *a2)
+{
+	a1->exp.ir_op.integer =
+	    a1->exp.ir_op.integer == a2->exp.ir_op.integer ? 0 : -1;
+}
+
+static void prv_neq_int_real(subtilis_exp_t *a1, subtilis_exp_t *a2)
+{
+	a1->exp.ir_op.integer =
+	    a1->exp.ir_op.integer == ((int32_t)a2->exp.ir_op.real) ? 0 : -1;
+	a1->type = SUBTILIS_EXP_CONST_INTEGER;
+}
+
+static void prv_neq_real_real(subtilis_exp_t *a1, subtilis_exp_t *a2)
+{
+	a1->exp.ir_op.integer =
+	    a1->exp.ir_op.real == a2->exp.ir_op.real ? 0 : -1;
+	a1->type = SUBTILIS_EXP_CONST_INTEGER;
+}
+
+subtilis_exp_t *subtilis_exp_neq(subtilis_parser_t *p, subtilis_exp_t *a1,
+				 subtilis_exp_t *a2, subtilis_error_t *err)
+{
+	subtilis_commutative_exp_t com = {
+	    .op_int_int = prv_neq_int_int,
+	    .op_int_real = prv_neq_int_real,
+	    .op_real_real = prv_neq_real_real,
+	    .in_var_imm = SUBTILIS_OP_INSTR_NEQI_I32,
+	    .in_var_var = SUBTILIS_OP_INSTR_NEQ_I32,
+	};
+
+	if ((a1->type == SUBTILIS_EXP_CONST_STRING ||
+	     a1->type == SUBTILIS_EXP_STRING) &&
+	    (a2->type == SUBTILIS_EXP_CONST_STRING ||
+	     a2->type == SUBTILIS_EXP_STRING)) {
+		subtilis_error_set_asssertion_failed(err);
+		return NULL;
+	}
+
+	return prv_exp_commutative(p, a1, a2, &com, err);
+}
+
 void subtilis_exp_delete(subtilis_exp_t *e)
 {
 	if (!e)

--- a/expression.h
+++ b/expression.h
@@ -17,6 +17,7 @@
 #include "buffer.h"
 #include "error.h"
 #include "ir.h"
+#include "parser.h"
 
 #ifndef __SUBTILIS_EXP_H
 #define __SUBTILIS_EXP_H
@@ -51,29 +52,29 @@ subtilis_exp_t *subtilis_exp_new_real(double real, subtilis_error_t *err);
 subtilis_exp_t *subtilis_exp_new_str(subtilis_buffer_t *str,
 				     subtilis_error_t *err);
 
-typedef subtilis_exp_t *(*subtilis_exp_fn_t)(subtilis_ir_program_t *,
+typedef subtilis_exp_t *(*subtilis_exp_fn_t)(subtilis_parser_t *,
 					     subtilis_exp_t *, subtilis_exp_t *,
 					     subtilis_error_t *err);
 
 /* These functions assume ownership of a1 and a2 */
-subtilis_exp_t *subtilis_exp_add(subtilis_ir_program_t *p, subtilis_exp_t *a1,
+subtilis_exp_t *subtilis_exp_add(subtilis_parser_t *p, subtilis_exp_t *a1,
 				 subtilis_exp_t *a2, subtilis_error_t *err);
-subtilis_exp_t *subtilis_exp_sub(subtilis_ir_program_t *p, subtilis_exp_t *a1,
+subtilis_exp_t *subtilis_exp_sub(subtilis_parser_t *p, subtilis_exp_t *a1,
 				 subtilis_exp_t *a2, subtilis_error_t *err);
-subtilis_exp_t *subtilis_exp_mul(subtilis_ir_program_t *p, subtilis_exp_t *a1,
+subtilis_exp_t *subtilis_exp_mul(subtilis_parser_t *p, subtilis_exp_t *a1,
 				 subtilis_exp_t *a2, subtilis_error_t *err);
-subtilis_exp_t *subtilis_exp_div(subtilis_ir_program_t *p, subtilis_exp_t *a1,
+subtilis_exp_t *subtilis_exp_div(subtilis_parser_t *p, subtilis_exp_t *a1,
 				 subtilis_exp_t *a2, subtilis_error_t *err);
-subtilis_exp_t *subtilis_exp_and(subtilis_ir_program_t *p, subtilis_exp_t *a1,
+subtilis_exp_t *subtilis_exp_and(subtilis_parser_t *p, subtilis_exp_t *a1,
 				 subtilis_exp_t *a2, subtilis_error_t *err);
-subtilis_exp_t *subtilis_exp_or(subtilis_ir_program_t *p, subtilis_exp_t *a1,
+subtilis_exp_t *subtilis_exp_or(subtilis_parser_t *p, subtilis_exp_t *a1,
 				subtilis_exp_t *a2, subtilis_error_t *err);
-subtilis_exp_t *subtilis_exp_eor(subtilis_ir_program_t *p, subtilis_exp_t *a1,
+subtilis_exp_t *subtilis_exp_eor(subtilis_parser_t *p, subtilis_exp_t *a1,
 				 subtilis_exp_t *a2, subtilis_error_t *err);
-subtilis_exp_t *subtilis_exp_unary_minus(subtilis_ir_program_t *p,
+subtilis_exp_t *subtilis_exp_unary_minus(subtilis_parser_t *p,
 					 subtilis_exp_t *e,
 					 subtilis_error_t *err);
-subtilis_exp_t *subtilis_exp_not(subtilis_ir_program_t *p, subtilis_exp_t *e,
+subtilis_exp_t *subtilis_exp_not(subtilis_parser_t *p, subtilis_exp_t *e,
 				 subtilis_error_t *err);
 
 void subtilis_exp_delete(subtilis_exp_t *e);

--- a/expression.h
+++ b/expression.h
@@ -76,7 +76,10 @@ subtilis_exp_t *subtilis_exp_unary_minus(subtilis_parser_t *p,
 					 subtilis_error_t *err);
 subtilis_exp_t *subtilis_exp_not(subtilis_parser_t *p, subtilis_exp_t *e,
 				 subtilis_error_t *err);
-
+subtilis_exp_t *subtilis_exp_eq(subtilis_parser_t *p, subtilis_exp_t *a1,
+				subtilis_exp_t *a2, subtilis_error_t *err);
+subtilis_exp_t *subtilis_exp_neq(subtilis_parser_t *p, subtilis_exp_t *a1,
+				 subtilis_exp_t *a2, subtilis_error_t *err);
 void subtilis_exp_delete(subtilis_exp_t *e);
 
 #endif

--- a/ir.c
+++ b/ir.c
@@ -246,6 +246,10 @@ static const subtilis_ir_op_desc_t op_dump_fns[] = {
 	{ "eori32", prv_dump_reg_reg_reg},   /* SUBTILIS_OP_INSTR_EOR_I32 */
 	{ "eorii32", prv_dump_reg_reg_i32},  /* SUBTILIS_OP_INSTR_EORI_I32 */
 	{ "noti32", prv_dump_reg_reg},       /* SUBTILIS_OP_INSTR_NOT_I32 */
+	{ "eqi32", prv_dump_reg_reg_reg},    /* SUBTILIS_OP_INSTR_EQ_I32 */
+	{ "eqii32", prv_dump_reg_reg_i32},   /* SUBTILIS_OP_INSTR_EQI_I32 */
+	{ "neqi32", prv_dump_reg_reg_reg},   /* SUBTILIS_OP_INSTR_NEQ_I32 */
+	{ "neqii32", prv_dump_reg_reg_i32},  /* SUBTILIS_OP_INSTR_NEQI_I32 */
 };
 
 /* clang-format on */

--- a/ir.h
+++ b/ir.h
@@ -481,6 +481,49 @@ typedef enum {
 	 */
 
 	SUBTILIS_OP_INSTR_NOT_I32,
+
+	/*
+	 * eqi32 r0, r1, r2
+	 *
+	 * Compares the 32 bit integers in r1 and r2, storing -1 in R0
+	 * if they are equal, and 0 otherwise.
+	 *
+	 * r0 = r1 == r2 ? -1 : 0
+	 */
+
+	SUBTILIS_OP_INSTR_EQ_I32,
+
+	/*
+	 * eqii32 r0, r1, i32
+	 *
+	 * Compares the 32 bit integers in r1 with a 32 bit immediate
+	 * constant, storing -1 in R0 if they are equal, and 0 otherwise.
+	 *
+	 * r0 = r1 == i32 ? -1 : 0
+	 */
+
+	SUBTILIS_OP_INSTR_EQI_I32,
+	/*
+	 * neqi32 r0, r1, r2
+	 *
+	 * Compares the 32 bit integers in r1 and r2, storing -1 in R0
+	 * if they are not equal, and 0 otherwise.
+	 *
+	 * r0 = r1 != r2 ? -1 : 0
+	 */
+
+	SUBTILIS_OP_INSTR_NEQ_I32,
+
+	/*
+	 * neqii32 r0, r1, i32
+	 *
+	 * Compares the 32 bit integers in r1 with a 32 bit immediate
+	 * constant, storing -1 in R0 if they are not equal, and 0 otherwise.
+	 *
+	 * r0 = r1 != i32 ? -1 : 0
+	 */
+
+	SUBTILIS_OP_INSTR_NEQI_I32,
 } subtilis_op_instr_type_t;
 
 // TODO: Need a type for pointer offsets.  These may not always

--- a/parser.c
+++ b/parser.c
@@ -127,7 +127,7 @@ static subtilis_exp_t *prv_unary_minus_exp(subtilis_parser_t *p,
 	e = prv_expression(p, t, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return NULL;
-	return subtilis_exp_unary_minus(p->p, e, err);
+	return subtilis_exp_unary_minus(p, e, err);
 }
 
 static subtilis_exp_t *prv_not_exp(subtilis_parser_t *p, subtilis_token_t *t,
@@ -138,7 +138,7 @@ static subtilis_exp_t *prv_not_exp(subtilis_parser_t *p, subtilis_token_t *t,
 	e = prv_expression(p, t, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return NULL;
-	return subtilis_exp_not(p->p, e, err);
+	return subtilis_exp_not(p, e, err);
 }
 
 static subtilis_exp_t *prv_priority1(subtilis_parser_t *p, subtilis_token_t *t,
@@ -254,7 +254,7 @@ static subtilis_exp_t *prv_priority3(subtilis_parser_t *p, subtilis_token_t *t,
 		if (err->type != SUBTILIS_ERROR_OK)
 			goto cleanup;
 
-		e1 = exp_fn(p->p, e1, e2, err);
+		e1 = exp_fn(p, e1, e2, err);
 		e2 = NULL;
 		if (err->type != SUBTILIS_ERROR_OK)
 			goto cleanup;
@@ -296,7 +296,7 @@ static subtilis_exp_t *prv_priority4(subtilis_parser_t *p, subtilis_token_t *t,
 		if (err->type != SUBTILIS_ERROR_OK)
 			goto cleanup;
 
-		e1 = exp_fn(p->p, e1, e2, err);
+		e1 = exp_fn(p, e1, e2, err);
 		e2 = NULL;
 		if (err->type != SUBTILIS_ERROR_OK)
 			goto cleanup;
@@ -334,7 +334,7 @@ static subtilis_exp_t *prv_priority6(subtilis_parser_t *p, subtilis_token_t *t,
 		e2 = prv_priority5(p, t, err);
 		if (err->type != SUBTILIS_ERROR_OK)
 			goto cleanup;
-		e1 = subtilis_exp_and(p->p, e1, e2, err);
+		e1 = subtilis_exp_and(p, e1, e2, err);
 		e2 = NULL;
 		if (err->type != SUBTILIS_ERROR_OK)
 			goto cleanup;
@@ -372,7 +372,7 @@ static subtilis_exp_t *prv_priority7(subtilis_parser_t *p, subtilis_token_t *t,
 		e2 = prv_priority6(p, t, err);
 		if (err->type != SUBTILIS_ERROR_OK)
 			goto cleanup;
-		e1 = exp_fn(p->p, e1, e2, err);
+		e1 = exp_fn(p, e1, e2, err);
 		e2 = NULL;
 		if (err->type != SUBTILIS_ERROR_OK)
 			goto cleanup;

--- a/parser_test.c
+++ b/parser_test.c
@@ -243,6 +243,26 @@ static const expression_test_t expression_tests[] = {
 	  "PRINT NOT TRUE\n"
 	  "PRINT NOT &fffffff0\n",
 	  "0\n-1\n0\n15\n"},
+	{ "parser_eq",
+	  "LET b% = &ff\n"
+	  "PRINT 10 = 5 + 5\n"
+	  "PRINT b% = 255\n"
+	  "PRINT b% = 254\n"
+	  "LET c% = 255\n"
+	  "PRINT c% = b%\n"
+	  "LET c% = b% = 254\n"
+	  "PRINT c%\n",
+	  "-1\n-1\n0\n-1\n0\n"},
+	{ "parser_neq",
+	  "LET b% = &ff\n"
+	  "PRINT 10 <> 5 + 5\n"
+	  "PRINT b% <> 255\n"
+	  "PRINT b% <> 254\n"
+	  "LET c% = 255\n"
+	  "PRINT c% <> b%\n"
+	  "LET c% = b% <> 254\n"
+	  "PRINT c%\n",
+	  "0\n0\n-1\n0\n-1\n"},
 };
 
 /* clang-format on */

--- a/unit_tests.c
+++ b/unit_tests.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <locale.h>
+
 #include "lexer_test.h"
 #include "parser_test.h"
 #include "symbol_table_test.h"
@@ -21,6 +23,8 @@
 int main(int argc, char *argv[])
 {
 	int failure = 0;
+
+	setlocale(LC_ALL, "C");
 
 	failure |= lexer_test();
 	failure |= symbol_table_test();

--- a/vm.c
+++ b/vm.c
@@ -212,6 +212,32 @@ static void prv_noti32(subitlis_vm_t *vm, subtilis_buffer_t *b,
 	vm->regs[ops[0].reg] = ~vm->regs[ops[1].reg];
 }
 
+static void prv_eqi32(subitlis_vm_t *vm, subtilis_buffer_t *b,
+		      subtilis_ir_operand_t *ops, subtilis_error_t *err)
+{
+	vm->regs[ops[0].reg] =
+	    vm->regs[ops[1].integer] == vm->regs[ops[2].integer] ? -1 : 0;
+}
+
+static void prv_eqii32(subitlis_vm_t *vm, subtilis_buffer_t *b,
+		       subtilis_ir_operand_t *ops, subtilis_error_t *err)
+{
+	vm->regs[ops[0].reg] = vm->regs[ops[1].reg] == ops[2].integer ? -1 : 0;
+}
+
+static void prv_neqi32(subitlis_vm_t *vm, subtilis_buffer_t *b,
+		       subtilis_ir_operand_t *ops, subtilis_error_t *err)
+{
+	vm->regs[ops[0].reg] =
+	    vm->regs[ops[1].integer] == vm->regs[ops[2].integer] ? 0 : -1;
+}
+
+static void prv_neqii32(subitlis_vm_t *vm, subtilis_buffer_t *b,
+			subtilis_ir_operand_t *ops, subtilis_error_t *err)
+{
+	vm->regs[ops[0].reg] = vm->regs[ops[1].reg] == ops[2].integer ? 0 : -1;
+}
+
 /* clang-format off */
 static subtilis_vm_op_fn op_execute_fns[] = {
 	prv_addi32,                          /* SUBTILIS_OP_INSTR_ADD_I32 */
@@ -254,6 +280,10 @@ static subtilis_vm_op_fn op_execute_fns[] = {
 	prv_eori32,                          /* SUBTILIS_OP_INSTR_EOR_I32 */
 	prv_eorii32,                         /* SUBTILIS_OP_INSTR_EORI_I32 */
 	prv_noti32,                          /* SUBTILIS_OP_INSTR_NOT_I32 */
+	prv_eqi32,                           /* SUBTILIS_OP_INSTR_EQ_I32 */
+	prv_eqii32,                          /* SUBTILIS_OP_INSTR_EQI_I32 */
+	prv_neqi32,                          /* SUBTILIS_OP_INSTR_NEQ_I32 */
+	prv_neqii32,                         /* SUBTILIS_OP_INSTR_NEQI_I32 */
 };
 
 /* clang-format on */


### PR DESCRIPTION
This PR fixes two issues

1. It ensures that the locale is set to the C locale so that floating point numbers are correctly parsed.
2. It adds support for the '=' and '<>' operators.