### PR TITLE
Add the IR matcher

### DIFF
--- a/ir.h
+++ b/ir.h
@@ -729,6 +729,7 @@ typedef void (*subtilis_ir_action_t)(subtilis_ir_program_t *p, size_t start,
 
 struct subtilis_ir_rule_t_ {
 	subtilis_ir_op_match_t matches[SUBTILIS_IR_MAX_MATCHES];
+	size_t matches_count;
 	subtilis_ir_action_t action;
 };
 
@@ -769,4 +770,7 @@ void subtilis_ir_program_add_label(subtilis_ir_program_t *p, size_t l,
 void subtilis_ir_parse_rules(const subtilis_ir_rule_raw_t *raw,
 			     subtilis_ir_rule_t *parsed, size_t count,
 			     subtilis_error_t *err);
+void subtilis_ir_match(subtilis_ir_program_t *p, subtilis_ir_rule_t *rules,
+		       size_t rule_count, void *user_data,
+		       subtilis_error_t *err);
 #endif

--- a/parser_test.c
+++ b/parser_test.c
@@ -22,10 +22,10 @@
 #include "parser.h"
 #include "vm.h"
 
-static int prv_test_wrapper(const char *text,
-			    int (*fn)(subtilis_lexer_t *, subtilis_parser_t *,
-				      const char *expected),
-			    const char *expected)
+int parser_test_wrapper(const char *text,
+			int (*fn)(subtilis_lexer_t *, subtilis_parser_t *,
+				  const char *expected),
+			const char *expected)
 {
 	subtilis_stream_t s;
 	subtilis_error_t err;
@@ -159,7 +159,7 @@ static int prv_test_let(void)
 			       "PRINT 10 + 10 + b%\n";
 
 	printf("parser_let");
-	return prv_test_wrapper(let_test, prv_check_eval_res, "119\n");
+	return parser_test_wrapper(let_test, prv_check_eval_res, "119\n");
 }
 
 struct expression_test_t_ {
@@ -347,9 +347,9 @@ static int prv_test_expressions(void)
 	for (i = 0; i < sizeof(expression_tests) / sizeof(expression_test_t);
 	     i++) {
 		printf("%s", expression_tests[i].name);
-		retval |= prv_test_wrapper(expression_tests[i].source,
-					   prv_check_eval_res,
-					   expression_tests[i].result);
+		retval |= parser_test_wrapper(expression_tests[i].source,
+					      prv_check_eval_res,
+					      expression_tests[i].result);
 	}
 
 	return retval;
@@ -358,14 +358,14 @@ static int prv_test_expressions(void)
 static int prv_test_print(void)
 {
 	printf("parser_print");
-	return prv_test_wrapper("PRINT (10 * 3 * 3 + 1) / 2",
-				prv_check_eval_res, "45\n");
+	return parser_test_wrapper("PRINT (10 * 3 * 3 + 1) / 2",
+				   prv_check_eval_res, "45\n");
 }
 
 static int prv_test_not_keyword(void)
 {
 	printf("parser_not_keyword");
-	return prv_test_wrapper("id", prv_check_not_keyword, NULL);
+	return parser_test_wrapper("id", prv_check_not_keyword, NULL);
 }
 
 int parser_test(void)

--- a/parser_test.h
+++ b/parser_test.h
@@ -17,6 +17,12 @@
 #ifndef __SUBTILIS_PARSER_TEST_H
 #define __SUBTILIS_PARSER_TEST_H
 
+#include "parser.h"
+
 int parser_test(void);
+int parser_test_wrapper(const char *text,
+			int (*fn)(subtilis_lexer_t *, subtilis_parser_t *,
+				  const char *expected),
+			const char *expected);
 
 #endif


### PR DESCRIPTION
This commits adds an IR pattern matcher that can be used to write
peephole optimizers for different targets.

Signed-off-by: Mark Ryan <markusdryan@gmail.com>