### PR TITLE
Generate code for some relational and logical operators

### DIFF
--- a/arm_gen.c
+++ b/arm_gen.c
@@ -138,26 +138,40 @@ void subtilis_arm_gen_if_gte_imm(subtilis_ir_program_t *p, size_t start,
 	prv_cmp_jmp_imm(p, start, user_data, SUBTILIS_ARM_CCODE_LT, err);
 }
 
+static void prv_data_simple(subtilis_ir_program_t *p, size_t start,
+			    void *user_data, subtilis_arm_instr_type_t itype,
+			    subtilis_arm_ccode_type_t ccode,
+			    subtilis_error_t *err)
+{
+	subtilis_arm_instr_t *instr;
+	subtilis_arm_data_instr_t *datai;
+	subtilis_arm_program_t *arm_p = user_data;
+	subtilis_ir_inst_t *ir_op = &p->ops[start]->op.instr;
+
+	instr = subtilis_arm_program_add_instr(arm_p, itype, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	datai = &instr->operands.data;
+	datai->ccode = ccode;
+	datai->dest = subtilis_arm_ir_to_arm_reg(ir_op->operands[0].reg);
+	datai->op1 = subtilis_arm_ir_to_arm_reg(ir_op->operands[1].reg);
+	datai->op2.type = SUBTILIS_ARM_OP2_REG;
+	datai->op2.op.reg = subtilis_arm_ir_to_arm_reg(ir_op->operands[2].reg);
+}
+
 static void prv_cmp_jmp(subtilis_ir_program_t *p, size_t start, void *user_data,
 			subtilis_arm_ccode_type_t ccode, subtilis_error_t *err)
 {
 	subtilis_arm_instr_t *instr;
 	subtilis_arm_br_instr_t *br;
-	subtilis_arm_data_instr_t *datai;
 	subtilis_arm_program_t *arm_p = user_data;
-	subtilis_ir_inst_t *cmp = &p->ops[start]->op.instr;
 	subtilis_ir_inst_t *jmp = &p->ops[start + 1]->op.instr;
 
-	instr =
-	    subtilis_arm_program_add_instr(arm_p, SUBTILIS_ARM_INSTR_CMP, err);
+	prv_data_simple(p, start, user_data, SUBTILIS_ARM_INSTR_CMP,
+			SUBTILIS_ARM_CCODE_AL, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
-
-	datai = &instr->operands.data;
-	datai->ccode = SUBTILIS_ARM_CCODE_AL;
-	datai->op1 = subtilis_arm_ir_to_arm_reg(cmp->operands[1].reg);
-	datai->op2.type = SUBTILIS_ARM_OP2_REG;
-	datai->op2.op.reg = subtilis_arm_ir_to_arm_reg(cmp->operands[2].reg);
 
 	instr =
 	    subtilis_arm_program_add_instr(arm_p, SUBTILIS_ARM_INSTR_B, err);
@@ -192,6 +206,104 @@ void subtilis_arm_gen_if_gte(subtilis_ir_program_t *p, size_t start,
 			     void *user_data, subtilis_error_t *err)
 {
 	prv_cmp_jmp(p, start, user_data, SUBTILIS_ARM_CCODE_LT, err);
+}
+
+static void prv_cmp_imm(subtilis_ir_program_t *p, size_t start, void *user_data,
+			subtilis_arm_ccode_type_t ok,
+			subtilis_arm_ccode_type_t nok, subtilis_error_t *err)
+{
+	subtilis_arm_reg_t dest;
+	subtilis_arm_reg_t op1;
+	subtilis_arm_program_t *arm_p = user_data;
+	subtilis_ir_inst_t *cmp = &p->ops[start]->op.instr;
+
+	op1 = subtilis_arm_ir_to_arm_reg(cmp->operands[1].reg);
+	subtilis_arm_cmp_imm(arm_p, SUBTILIS_ARM_CCODE_AL, op1,
+			     cmp->operands[2].integer, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	dest = subtilis_arm_ir_to_arm_reg(cmp->operands[0].reg);
+	subtilis_arm_mov_imm(arm_p, ok, false, dest, -1, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+	subtilis_arm_mov_imm(arm_p, nok, false, dest, 0, err);
+}
+
+void subtilis_arm_gen_gtii32(subtilis_ir_program_t *p, size_t start,
+			     void *user_data, subtilis_error_t *err)
+{
+	prv_cmp_imm(p, start, user_data, SUBTILIS_ARM_CCODE_GT,
+		    SUBTILIS_ARM_CCODE_LE, err);
+}
+
+void subtilis_arm_gen_ltii32(subtilis_ir_program_t *p, size_t start,
+			     void *user_data, subtilis_error_t *err)
+{
+	prv_cmp_imm(p, start, user_data, SUBTILIS_ARM_CCODE_LT,
+		    SUBTILIS_ARM_CCODE_GE, err);
+}
+
+void subtilis_arm_gen_gteii32(subtilis_ir_program_t *p, size_t start,
+			      void *user_data, subtilis_error_t *err)
+{
+	prv_cmp_imm(p, start, user_data, SUBTILIS_ARM_CCODE_GE,
+		    SUBTILIS_ARM_CCODE_LT, err);
+}
+
+void subtilis_arm_gen_lteii32(subtilis_ir_program_t *p, size_t start,
+			      void *user_data, subtilis_error_t *err)
+{
+	prv_cmp_imm(p, start, user_data, SUBTILIS_ARM_CCODE_LE,
+		    SUBTILIS_ARM_CCODE_GT, err);
+}
+
+static void prv_cmp(subtilis_ir_program_t *p, size_t start, void *user_data,
+		    subtilis_arm_ccode_type_t ok, subtilis_arm_ccode_type_t nok,
+		    subtilis_error_t *err)
+{
+	subtilis_arm_reg_t dest;
+	subtilis_arm_program_t *arm_p = user_data;
+	subtilis_ir_inst_t *cmp = &p->ops[start]->op.instr;
+
+	prv_data_simple(p, start, user_data, SUBTILIS_ARM_INSTR_CMP,
+			SUBTILIS_ARM_CCODE_AL, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	dest = subtilis_arm_ir_to_arm_reg(cmp->operands[0].reg);
+	subtilis_arm_mov_imm(arm_p, ok, false, dest, -1, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+	subtilis_arm_mov_imm(arm_p, nok, false, dest, 0, err);
+}
+
+void subtilis_arm_gen_gti32(subtilis_ir_program_t *p, size_t start,
+			    void *user_data, subtilis_error_t *err)
+{
+	prv_cmp(p, start, user_data, SUBTILIS_ARM_CCODE_GT,
+		SUBTILIS_ARM_CCODE_LE, err);
+}
+
+void subtilis_arm_gen_lti32(subtilis_ir_program_t *p, size_t start,
+			    void *user_data, subtilis_error_t *err)
+{
+	prv_cmp(p, start, user_data, SUBTILIS_ARM_CCODE_LT,
+		SUBTILIS_ARM_CCODE_GE, err);
+}
+
+void subtilis_arm_gen_gtei32(subtilis_ir_program_t *p, size_t start,
+			     void *user_data, subtilis_error_t *err)
+{
+	prv_cmp(p, start, user_data, SUBTILIS_ARM_CCODE_GE,
+		SUBTILIS_ARM_CCODE_LT, err);
+}
+
+void subtilis_arm_gen_ltei32(subtilis_ir_program_t *p, size_t start,
+			     void *user_data, subtilis_error_t *err)
+{
+	prv_cmp(p, start, user_data, SUBTILIS_ARM_CCODE_LE,
+		SUBTILIS_ARM_CCODE_GT, err);
 }
 
 void subtilis_arm_gen_jump(subtilis_ir_program_t *p, size_t start,
@@ -237,4 +349,25 @@ void subtilis_arm_gen_jmpc(subtilis_ir_program_t *p, size_t start,
 	br->ccode = SUBTILIS_ARM_CCODE_EQ;
 	br->link = false;
 	br->label = jmp->operands[2].label;
+}
+
+void subtilis_arm_gen_eor(subtilis_ir_program_t *p, size_t start,
+			  void *user_data, subtilis_error_t *err)
+{
+	prv_data_simple(p, start, user_data, SUBTILIS_ARM_INSTR_EOR,
+			SUBTILIS_ARM_CCODE_AL, err);
+}
+
+void subtilis_arm_gen_or(subtilis_ir_program_t *p, size_t start,
+			 void *user_data, subtilis_error_t *err)
+{
+	prv_data_simple(p, start, user_data, SUBTILIS_ARM_INSTR_ORR,
+			SUBTILIS_ARM_CCODE_AL, err);
+}
+
+void subtilis_arm_gen_and(subtilis_ir_program_t *p, size_t start,
+			  void *user_data, subtilis_error_t *err)
+{
+	prv_data_simple(p, start, user_data, SUBTILIS_ARM_INSTR_AND,
+			SUBTILIS_ARM_CCODE_AL, err);
 }

--- a/arm_gen.h
+++ b/arm_gen.h
@@ -49,4 +49,26 @@ void subtilis_arm_gen_jump(subtilis_ir_program_t *p, size_t start,
 			   void *user_data, subtilis_error_t *err);
 void subtilis_arm_gen_jmpc(subtilis_ir_program_t *p, size_t start,
 			   void *user_data, subtilis_error_t *err);
+void subtilis_arm_gen_eor(subtilis_ir_program_t *p, size_t start,
+			  void *user_data, subtilis_error_t *err);
+void subtilis_arm_gen_or(subtilis_ir_program_t *p, size_t start,
+			 void *user_data, subtilis_error_t *err);
+void subtilis_arm_gen_and(subtilis_ir_program_t *p, size_t start,
+			  void *user_data, subtilis_error_t *err);
+void subtilis_arm_gen_gtii32(subtilis_ir_program_t *p, size_t start,
+			     void *user_data, subtilis_error_t *err);
+void subtilis_arm_gen_ltii32(subtilis_ir_program_t *p, size_t start,
+			     void *user_data, subtilis_error_t *err);
+void subtilis_arm_gen_gteii32(subtilis_ir_program_t *p, size_t start,
+			      void *user_data, subtilis_error_t *err);
+void subtilis_arm_gen_lteii32(subtilis_ir_program_t *p, size_t start,
+			      void *user_data, subtilis_error_t *err);
+void subtilis_arm_gen_gti32(subtilis_ir_program_t *p, size_t start,
+			    void *user_data, subtilis_error_t *err);
+void subtilis_arm_gen_lti32(subtilis_ir_program_t *p, size_t start,
+			    void *user_data, subtilis_error_t *err);
+void subtilis_arm_gen_gtei32(subtilis_ir_program_t *p, size_t start,
+			     void *user_data, subtilis_error_t *err);
+void subtilis_arm_gen_ltei32(subtilis_ir_program_t *p, size_t start,
+			     void *user_data, subtilis_error_t *err);
 #endif

--- a/examples/while
+++ b/examples/while
@@ -1,5 +1,6 @@
 LET i% = 0
-WHILE i% < 5
+LET c%=10
+WHILE i% > c%
   PRINT i%
   LET i%=i%+1
 ENDWHILE

--- a/riscos_arm2.c
+++ b/riscos_arm2.c
@@ -56,6 +56,14 @@ const subtilis_ir_rule_raw_t riscos_arm2_rules[] = {
 	{"jmpc *, label_1, *\n"
 	"label_1\n",
 		 subtilis_arm_gen_jmpc},
+	{"gtii32 *, *, *\n", subtilis_arm_gen_gtii32},
+	{"ltii32 *, *, *\n", subtilis_arm_gen_ltii32},
+	{"gteii32 *, *, *\n", subtilis_arm_gen_gteii32},
+	{"lteii32 *, *, *\n", subtilis_arm_gen_lteii32},
+	{"gti32 *, *, *\n", subtilis_arm_gen_gti32},
+	{"lti32 *, *, *\n", subtilis_arm_gen_lti32},
+	{"gtei32 *, *, *\n", subtilis_arm_gen_gtei32},
+	{"ltei32 *, *, *\n", subtilis_arm_gen_ltei32},
 	{"movii32 *, *", subtilis_arm_gen_movii32},
 	{"addii32 *, *, *", subtilis_arm_gen_addii32},
 	{"storeoi32 *, *, *", subtilis_arm_gen_storeoi32},
@@ -63,6 +71,9 @@ const subtilis_ir_rule_raw_t riscos_arm2_rules[] = {
 	{"label_1", subtilis_arm_gen_label},
 	{"printi32 *\n", subtilis_riscos_arm_printi},
 	{"jmp *\n", subtilis_arm_gen_jump},
+	{"andi32 *, *, *\n", subtilis_arm_gen_and},
+	{"ori32 *, *, *\n", subtilis_arm_gen_or},
+	{"eori32 *, *, *\n", subtilis_arm_gen_eor},
 };
 
 const size_t riscos_arm2_rules_count = sizeof(riscos_arm2_rules) /


### PR DESCRIPTION
Code is now generated for all logical operators involving only
registers and all relational operators apart from eq and neq.

Signed-off-by: Mark Ryan <markusdryan@gmail.com>