### PR TITLE
Add arm_walker and fix checkpatch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ install:
 
 script:
  - CFLAGS="-g -fsanitize=address -fno-omit-frame-pointer -Wall -Werror" make check
- - perl checkpatch.pl --no-tree -f --strict --show-types --ignore NEW_TYPEDEFS --ignore PREFER_KERNEL_TYPES --ignore SPLIT_STRING --ignore UNNECESSARY_PARENTHESES *.c *.h
+ - perl checkpatch.pl --no-tree -f --strict --show-types --ignore NEW_TYPEDEFS --ignore PREFER_KERNEL_TYPES --ignore SPLIT_STRING --ignore UNNECESSARY_PARENTHESES --ignore OPEN_ENDED_LINE *.c *.h
  - ./check-format.sh

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-DEPS = stream.h lexer.h config.h error.h utils.h keywords.h buffer.h expression.h ir.h hash_table.h symbol_table.h vm.h arm_core.h riscos_arm.h riscos_arm2.h arm_gen.h
-OBJ = stream.o lexer.o error.o utils.o keywords.o buffer.o parser.o expression.o ir.o hash_table.o symbol_table.o arm_core.o riscos_arm.o riscos_arm2.o arm_gen.o
+DEPS = stream.h lexer.h config.h error.h utils.h keywords.h buffer.h expression.h ir.h hash_table.h symbol_table.h vm.h arm_core.h riscos_arm.h riscos_arm2.h arm_gen.h arm_walker.h
+OBJ = stream.o lexer.o error.o utils.o keywords.o buffer.o parser.o expression.o ir.o hash_table.o symbol_table.o arm_core.o riscos_arm.o riscos_arm2.o arm_gen.o arm_walker.o
 UNIT_OBJS = unit_tests.o lexer_test.o parser_test.o symbol_table_test.o vm.o ir_test.o arm_core_test.o
 
 CFLAGS ?= -O3

--- a/ROMakefile
+++ b/ROMakefile
@@ -2,7 +2,7 @@
 
 COMPONENT = basicc
 
-OBJS = stream lexer error compiler utils keywords buffer parser expression ir hash_table symbol_table arm_core riscos_arm riscos_arm2 arm_gen
+OBJS = stream lexer error compiler utils keywords buffer parser expression ir hash_table symbol_table arm_core riscos_arm riscos_arm2 arm_gen arm_walker
 
 CFLAGS ?= -Wxla
 

--- a/arm_walker.c
+++ b/arm_walker.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2017 Mark Ryan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <limits.h>
+
+#include "arm_walker.h"
+
+static void prv_walk_instr(subtlis_arm_walker_t *walker,
+			   subtilis_arm_instr_t *instr, subtilis_error_t *err)
+{
+	switch (instr->type) {
+	case SUBTILIS_ARM_INSTR_AND:
+	case SUBTILIS_ARM_INSTR_EOR:
+	case SUBTILIS_ARM_INSTR_SUB:
+	case SUBTILIS_ARM_INSTR_RSB:
+	case SUBTILIS_ARM_INSTR_ADD:
+	case SUBTILIS_ARM_INSTR_ADC:
+	case SUBTILIS_ARM_INSTR_SBC:
+	case SUBTILIS_ARM_INSTR_RSC:
+	case SUBTILIS_ARM_INSTR_TST:
+	case SUBTILIS_ARM_INSTR_TEQ:
+	case SUBTILIS_ARM_INSTR_ORR:
+	case SUBTILIS_ARM_INSTR_BIC:
+	case SUBTILIS_ARM_INSTR_MUL:
+	case SUBTILIS_ARM_INSTR_MLA:
+		walker->data_fn(walker->user_data, instr->type,
+				&instr->operands.data, err);
+		break;
+	case SUBTILIS_ARM_INSTR_CMP:
+	case SUBTILIS_ARM_INSTR_CMN:
+		walker->cmp_fn(walker->user_data, instr->type,
+			       &instr->operands.data, err);
+		break;
+	case SUBTILIS_ARM_INSTR_MOV:
+	case SUBTILIS_ARM_INSTR_MVN:
+		walker->mov_fn(walker->user_data, instr->type,
+			       &instr->operands.data, err);
+		break;
+	case SUBTILIS_ARM_INSTR_LDR:
+	case SUBTILIS_ARM_INSTR_STR:
+		walker->stran_fn(walker->user_data, instr->type,
+				 &instr->operands.stran, err);
+		break;
+	case SUBTILIS_ARM_INSTR_LDM:
+	case SUBTILIS_ARM_INSTR_STM:
+		walker->mtran_fn(walker->user_data, instr->type,
+				 &instr->operands.mtran, err);
+		break;
+	case SUBTILIS_ARM_INSTR_B:
+	case SUBTILIS_ARM_INSTR_BL:
+		walker->br_fn(walker->user_data, instr->type,
+			      &instr->operands.br, err);
+		break;
+	case SUBTILIS_ARM_INSTR_SWI:
+		walker->swi_fn(walker->user_data, instr->type,
+			       &instr->operands.swi, err);
+		break;
+	case SUBTILIS_ARM_INSTR_LDRC:
+		walker->ldrc_fn(walker->user_data, instr->type,
+				&instr->operands.ldrc, err);
+		break;
+	}
+}
+
+void subtilis_arm_walk(subtilis_arm_program_t *arm_p,
+		       subtlis_arm_walker_t *walker, subtilis_error_t *err)
+{
+	subtilis_arm_op_t *op;
+	size_t i;
+
+	for (i = 0; i < arm_p->len; i++) {
+		op = &arm_p->ops[i];
+		switch (op->type) {
+		case SUBTILIS_OP_LABEL:
+			walker->label_fn(walker, op->op.label, err);
+			break;
+		case SUBTILIS_OP_INSTR:
+			prv_walk_instr(walker, &op->op.instr, err);
+			break;
+		default:
+			subtilis_error_set_asssertion_failed(err);
+			break;
+		}
+		if (err->type != SUBTILIS_ERROR_OK)
+			return;
+	}
+}

--- a/arm_walker.h
+++ b/arm_walker.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2017 Mark Ryan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __SUBTILIS_ARM_WALKER_H
+#define __SUBTILIS_ARM_WALKER_H
+
+#include <stddef.h>
+
+#include "arm_core.h"
+#include "error.h"
+
+typedef struct subtlis_arm_walker_t_ subtlis_arm_walker_t;
+
+struct subtlis_arm_walker_t_ {
+	void *user_data;
+	void (*label_fn)(void *user_data, size_t label, subtilis_error_t *err);
+	void (*data_fn)(void *user_data, subtilis_arm_instr_type_t type,
+			subtilis_arm_data_instr_t *instr,
+			subtilis_error_t *err);
+	void (*cmp_fn)(void *user_data, subtilis_arm_instr_type_t type,
+		       subtilis_arm_data_instr_t *instr, subtilis_error_t *err);
+	void (*mov_fn)(void *user_data, subtilis_arm_instr_type_t type,
+		       subtilis_arm_data_instr_t *instr, subtilis_error_t *err);
+	void (*stran_fn)(void *user_data, subtilis_arm_instr_type_t type,
+			 subtilis_arm_stran_instr_t *instr,
+			 subtilis_error_t *err);
+	void (*mtran_fn)(void *user_data, subtilis_arm_instr_type_t type,
+			 subtilis_arm_mtran_instr_t *instr,
+			 subtilis_error_t *err);
+	void (*br_fn)(void *user_data, subtilis_arm_instr_type_t type,
+		      subtilis_arm_br_instr_t *instr, subtilis_error_t *err);
+	void (*swi_fn)(void *user_data, subtilis_arm_instr_type_t type,
+		       subtilis_arm_swi_instr_t *instr, subtilis_error_t *err);
+	void (*ldrc_fn)(void *user_data, subtilis_arm_instr_type_t type,
+			subtilis_arm_ldrc_instr_t *instr,
+			subtilis_error_t *err);
+};
+
+void subtilis_arm_walk(subtilis_arm_program_t *arm_p,
+		       subtlis_arm_walker_t *walker, subtilis_error_t *err);
+
+#endif


### PR DESCRIPTION
This PR does two things.

1. It updates the travis file to disable a check added by a new version of checkpatch.
2. It adds the arm_walker, a routine for walking through arm programs.