### PR TITLE
A few small changes to prepare for register allocation

### DIFF
--- a/arm_core.c
+++ b/arm_core.c
@@ -58,6 +58,7 @@ subtilis_arm_program_t *subtilis_arm_program_new(size_t reg_counter,
 	p->label_counter = label_counter;
 	p->len = 0;
 	p->ops = NULL;
+	p->op_order = NULL;
 	p->globals = globals;
 	p->constants = NULL;
 	p->constant_count = 0;
@@ -72,6 +73,7 @@ void subtilis_arm_program_delete(subtilis_arm_program_t *p)
 		return;
 
 	free(p->constants);
+	free(p->op_order);
 	free(p->ops);
 	free(p);
 }
@@ -113,6 +115,7 @@ static subtilis_arm_reg_t prv_acquire_new_reg(subtilis_arm_program_t *p)
 static void prv_ensure_buffer(subtilis_arm_program_t *p, subtilis_error_t *err)
 {
 	subtilis_arm_op_t *new_ops;
+	size_t *new_op_order;
 	size_t new_max;
 
 	if (p->len < p->max_len)
@@ -124,8 +127,15 @@ static void prv_ensure_buffer(subtilis_arm_program_t *p, subtilis_error_t *err)
 		subtilis_error_set_oom(err);
 		return;
 	}
+	new_op_order = realloc(p->op_order, new_max * sizeof(size_t));
+	if (!new_op_order) {
+		free(new_ops);
+		subtilis_error_set_oom(err);
+		return;
+	}
 	p->max_len = new_max;
 	p->ops = new_ops;
+	p->op_order = new_op_order;
 }
 
 void subtilis_arm_program_add_label(subtilis_arm_program_t *p, size_t label,
@@ -136,6 +146,7 @@ void subtilis_arm_program_add_label(subtilis_arm_program_t *p, size_t label,
 	prv_ensure_buffer(p, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
+	p->op_order[p->len] = p->len;
 	op = &p->ops[p->len++];
 	op->type = SUBTILIS_OP_LABEL;
 	op->op.label = label;
@@ -174,6 +185,7 @@ subtilis_arm_program_add_instr(subtilis_arm_program_t *p,
 	prv_ensure_buffer(p, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return NULL;
+	p->op_order[p->len] = p->len;
 	op = &p->ops[p->len++];
 	memset(op, 0, sizeof(*op));
 	op->type = SUBTILIS_OP_INSTR;
@@ -195,6 +207,7 @@ subtilis_arm_instr_t *subtilis_arm_program_dup_instr(subtilis_arm_program_t *p,
 	if (err->type != SUBTILIS_ERROR_OK)
 		return NULL;
 	p->ops[p->len] = p->ops[p->len - 1];
+	p->op_order[p->len] = p->len;
 	op = &p->ops[p->len++];
 	return &op->op.instr;
 }

--- a/arm_core.h
+++ b/arm_core.h
@@ -210,6 +210,7 @@ struct subtilis_arm_program_t_ {
 	size_t max_len;
 	subtilis_arm_op_t *ops;
 	size_t globals;
+	size_t *op_order;
 	subtilis_arm_constant_t *constants;
 	size_t constant_count;
 	size_t max_constants;

--- a/arm_core.h
+++ b/arm_core.h
@@ -236,6 +236,12 @@ bool subtilis_arm_encode_imm(int32_t num, uint32_t *encoded);
 bool subtilis_arm_encode_lvl2_imm(int32_t num, uint32_t *encoded1,
 				  uint32_t *encoded2);
 subtilis_arm_reg_t subtilis_arm_ir_to_arm_reg(size_t ir_reg);
+size_t subtilis_add_data_imm_ldr_datai(subtilis_arm_program_t *p,
+				       subtilis_arm_instr_type_t itype,
+				       subtilis_arm_ccode_type_t ccode,
+				       bool status, subtilis_arm_reg_t dest,
+				       subtilis_arm_reg_t op1, int32_t op2,
+				       subtilis_error_t *err);
 void subtilis_arm_add_addsub_imm(subtilis_arm_program_t *p,
 				 subtilis_arm_instr_type_t itype,
 				 subtilis_arm_instr_type_t alt_type,

--- a/arm_walker.c
+++ b/arm_walker.c
@@ -82,7 +82,7 @@ void subtilis_arm_walk(subtilis_arm_program_t *arm_p,
 	size_t i;
 
 	for (i = 0; i < arm_p->len; i++) {
-		op = &arm_p->ops[i];
+		op = &arm_p->ops[arm_p->op_order[i]];
 		switch (op->type) {
 		case SUBTILIS_OP_LABEL:
 			walker->label_fn(walker, op->op.label, err);

--- a/riscos_arm.c
+++ b/riscos_arm.c
@@ -18,17 +18,18 @@
 
 #include "riscos_arm.h"
 
-void prv_add_preamble(subtilis_arm_program_t *arm_p, subtilis_error_t *err)
+size_t prv_add_preamble(subtilis_arm_program_t *arm_p, subtilis_error_t *err)
 {
 	subtilis_arm_instr_t *instr;
 	subtilis_arm_reg_t dest;
 	subtilis_arm_reg_t op1;
 	subtilis_arm_reg_t op2;
+	size_t label;
 
 	instr =
 	    subtilis_arm_program_add_instr(arm_p, SUBTILIS_ARM_INSTR_SWI, err);
 	if (err->type != SUBTILIS_ERROR_OK)
-		return;
+		return 0;
 
 	instr->operands.swi.ccode = SUBTILIS_ARM_CCODE_AL;
 	instr->operands.swi.code = 0x10;
@@ -41,16 +42,18 @@ void prv_add_preamble(subtilis_arm_program_t *arm_p, subtilis_error_t *err)
 	op1.type = SUBTILIS_ARM_REG_FIXED;
 	op1.num = 1;
 
-	subtilis_arm_add_sub_imm(arm_p, SUBTILIS_ARM_CCODE_AL, false, dest, op1,
-				 arm_p->globals, err);
+	label = subtilis_add_data_imm_ldr_datai(arm_p, SUBTILIS_ARM_INSTR_SUB,
+						SUBTILIS_ARM_CCODE_AL, false,
+						dest, op1, arm_p->globals, err);
 	if (err->type != SUBTILIS_ERROR_OK)
-		return;
+		return 0;
 
 	dest.num = 13;
 	op2.type = SUBTILIS_ARM_REG_FIXED;
 	op2.num = 12;
 	subtilis_arm_mov_reg(arm_p, SUBTILIS_ARM_CCODE_AL, false, dest, op2,
 			     err);
+	return label;
 }
 
 void prv_add_coda(subtilis_arm_program_t *arm_p, subtilis_error_t *err)
@@ -92,6 +95,7 @@ subtilis_riscos_generate(
 {
 	subtilis_ir_rule_t *parsed;
 	subtilis_arm_program_t *arm_p = NULL;
+	//	size_t stack_frame_label;
 
 	parsed = malloc(sizeof(*parsed) * rule_count);
 	if (!parsed) {
@@ -108,7 +112,8 @@ subtilis_riscos_generate(
 	if (err->type != SUBTILIS_ERROR_OK)
 		goto cleanup;
 
-	prv_add_preamble(arm_p, err);
+	//	stack_frame_label = prv_add_preamble(arm_p, err);
+	(void)prv_add_preamble(arm_p, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		goto cleanup;
 


### PR DESCRIPTION
- A constant stored in the code is always used to set the size of the stack frame, even if it can be encoded within an immediate value of op2.
- Operations in a subtilis_arm_program_t are now accessed indirectly through a secondary array.  This allows us to insert new instructions without copying the entire program.