### PR TITLE
 Add register allocator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 DEPS = stream.h lexer.h config.h error.h utils.h keywords.h buffer.h expression.h ir.h hash_table.h symbol_table.h vm.h arm_core.h riscos_arm.h riscos_arm2.h arm_gen.h arm_walker.h
-OBJ = stream.o lexer.o error.o utils.o keywords.o buffer.o parser.o expression.o ir.o hash_table.o symbol_table.o arm_core.o riscos_arm.o riscos_arm2.o arm_gen.o arm_walker.o
+OBJ = stream.o lexer.o error.o utils.o keywords.o buffer.o parser.o expression.o ir.o hash_table.o symbol_table.o arm_core.o riscos_arm.o riscos_arm2.o arm_gen.o arm_walker.o arm_reg_alloc.o
 UNIT_OBJS = unit_tests.o lexer_test.o parser_test.o symbol_table_test.o vm.o ir_test.o arm_core_test.o
 
 CFLAGS ?= -O3
 CFLAGS += -Wall -Werror
 
 %.o: %.c $(DEPS)
-	$(CC) -c -o $@ $< $(CFLAGS)
+	$(CC) -c $(CFLAGS) -o $@ $< 
 
 basicc: compiler.o $(OBJ)
-	$(CC) -o $@ $^ $(CFLAGS)
+	$(CC) $(CFLAGS) -o $@ $^
 
 unit_tests: $(UNIT_OBJS) $(OBJ)
 	$(CC) -o $@ $^ $(CFLAGS)

--- a/arm_core.c
+++ b/arm_core.c
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -42,7 +43,62 @@ static const uint32_t subitlis_arm_imm_mask[] = {
 
 /* clang-format on */
 
-subtilis_arm_program_t *subtilis_arm_program_new(size_t reg_counter,
+subtilis_arm_op_pool_t *subtilis_arm_op_pool_new(subtilis_error_t *err)
+{
+	subtilis_arm_op_pool_t *pool = malloc(sizeof(subtilis_arm_op_pool_t));
+
+	if (!pool) {
+		subtilis_error_set_oom(err);
+		return NULL;
+	}
+	pool->len = 0;
+	pool->max_len = 0;
+	pool->ops = NULL;
+	return pool;
+}
+
+void subtilis_arm_op_pool_reset(subtilis_arm_op_pool_t *pool) { pool->len = 0; }
+
+void subtilis_arm_op_pool_delete(subtilis_arm_op_pool_t *pool)
+{
+	if (pool) {
+		free(pool->ops);
+		free(pool);
+	}
+}
+
+size_t subtilis_arm_op_pool_alloc(subtilis_arm_op_pool_t *pool,
+				  subtilis_error_t *err)
+{
+	subtilis_arm_op_t *new_ops;
+	size_t new_max;
+	size_t new_op;
+
+	new_op = pool->len;
+	if (new_op < pool->max_len) {
+		pool->len++;
+		return new_op;
+	}
+
+	if (pool->max_len > SIZE_MAX - SUBTILIS_CONFIG_PROGRAM_GRAN) {
+		subtilis_error_set_oom(err);
+		return SIZE_MAX;
+	}
+
+	new_max = pool->max_len + SUBTILIS_CONFIG_PROGRAM_GRAN;
+	new_ops = realloc(pool->ops, new_max * sizeof(subtilis_arm_op_t));
+	if (!new_ops) {
+		subtilis_error_set_oom(err);
+		return SIZE_MAX;
+	}
+	pool->max_len = new_max;
+	pool->ops = new_ops;
+	pool->len++;
+	return new_op;
+}
+
+subtilis_arm_program_t *subtilis_arm_program_new(subtilis_arm_op_pool_t *pool,
+						 size_t reg_counter,
 						 size_t label_counter,
 						 size_t globals,
 						 subtilis_error_t *err)
@@ -53,15 +109,16 @@ subtilis_arm_program_t *subtilis_arm_program_new(size_t reg_counter,
 		subtilis_error_set_oom(err);
 		return NULL;
 	}
-	p->max_len = 0;
 	p->reg_counter = reg_counter;
 	p->label_counter = label_counter;
 	p->len = 0;
-	p->ops = NULL;
+	p->first_op = SIZE_MAX;
+	p->last_op = SIZE_MAX;
 	p->globals = globals;
 	p->constants = NULL;
 	p->constant_count = 0;
 	p->max_constants = 0;
+	p->pool = pool;
 
 	return p;
 }
@@ -72,7 +129,6 @@ void subtilis_arm_program_delete(subtilis_arm_program_t *p)
 		return;
 
 	free(p->constants);
-	free(p->ops);
 	free(p);
 }
 
@@ -110,22 +166,59 @@ static subtilis_arm_reg_t prv_acquire_new_reg(subtilis_arm_program_t *p)
 	return subtilis_arm_ir_to_arm_reg(p->reg_counter++);
 }
 
-static void prv_ensure_buffer(subtilis_arm_program_t *p, subtilis_error_t *err)
+static subtilis_arm_op_t *prv_append_op(subtilis_arm_program_t *p,
+					subtilis_error_t *err)
 {
-	subtilis_arm_op_t *new_ops;
-	size_t new_max;
+	size_t ptr;
+	subtilis_arm_op_t *op;
+	size_t prev = p->last_op;
 
-	if (p->len < p->max_len)
-		return;
+	ptr = subtilis_arm_op_pool_alloc(p->pool, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return NULL;
+	op = &p->pool->ops[ptr];
+	memset(op, 0, sizeof(*op));
+	op->next = SIZE_MAX;
+	op->prev = prev;
+	if (p->first_op == SIZE_MAX)
+		p->first_op = ptr;
+	else
+		p->pool->ops[p->last_op].next = ptr;
+	p->last_op = ptr;
+	p->len++;
 
-	new_max = p->max_len + SUBTILIS_CONFIG_PROGRAM_GRAN;
-	new_ops = realloc(p->ops, new_max * sizeof(subtilis_arm_op_t));
-	if (!new_ops) {
-		subtilis_error_set_oom(err);
-		return;
-	}
-	p->max_len = new_max;
-	p->ops = new_ops;
+	return op;
+}
+
+static subtilis_arm_op_t *prv_insert_op(subtilis_arm_program_t *p,
+					subtilis_arm_op_t *pos,
+					subtilis_error_t *err)
+{
+	size_t ptr;
+	size_t old_ptr;
+	subtilis_arm_op_t *op;
+
+	ptr = subtilis_arm_op_pool_alloc(p->pool, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return NULL;
+
+	if (pos->prev == SIZE_MAX)
+		old_ptr = p->first_op;
+	else
+		old_ptr = p->pool->ops[pos->prev].next;
+
+	op = &p->pool->ops[ptr];
+	memset(op, 0, sizeof(*op));
+	op->next = old_ptr;
+	op->prev = pos->prev;
+	p->pool->ops[pos->prev].next = ptr;
+	pos->prev = ptr;
+
+	if (old_ptr == p->first_op)
+		p->first_op = ptr;
+	p->len++;
+
+	return op;
 }
 
 void subtilis_arm_program_add_label(subtilis_arm_program_t *p, size_t label,
@@ -133,10 +226,9 @@ void subtilis_arm_program_add_label(subtilis_arm_program_t *p, size_t label,
 {
 	subtilis_arm_op_t *op;
 
-	prv_ensure_buffer(p, err);
+	op = prv_append_op(p, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
-	op = &p->ops[p->len++];
 	op->type = SUBTILIS_OP_LABEL;
 	op->op.label = label;
 }
@@ -171,11 +263,29 @@ subtilis_arm_program_add_instr(subtilis_arm_program_t *p,
 {
 	subtilis_arm_op_t *op;
 
-	prv_ensure_buffer(p, err);
+	op = prv_append_op(p, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return NULL;
-	op = &p->ops[p->len++];
-	memset(op, 0, sizeof(*op));
+
+	op->type = SUBTILIS_OP_INSTR;
+	op->op.instr.type = type;
+	return &op->op.instr;
+}
+
+/* clang-format off */
+subtilis_arm_instr_t *
+subtilis_arm_program_insert_instr(subtilis_arm_program_t *p,
+				  subtilis_arm_op_t *pos,
+				  subtilis_arm_instr_type_t type,
+				  subtilis_error_t *err)
+/* clang-format on */
+{
+	subtilis_arm_op_t *op;
+
+	op = prv_insert_op(p, pos, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return NULL;
+
 	op->type = SUBTILIS_OP_INSTR;
 	op->op.instr.type = type;
 	return &op->op.instr;
@@ -184,6 +294,7 @@ subtilis_arm_program_add_instr(subtilis_arm_program_t *p,
 subtilis_arm_instr_t *subtilis_arm_program_dup_instr(subtilis_arm_program_t *p,
 						     subtilis_error_t *err)
 {
+	subtilis_arm_op_t *src;
 	subtilis_arm_op_t *op;
 
 	if (p->len == 0) {
@@ -191,11 +302,14 @@ subtilis_arm_instr_t *subtilis_arm_program_dup_instr(subtilis_arm_program_t *p,
 		return NULL;
 	}
 
-	prv_ensure_buffer(p, err);
+	src = &p->pool->ops[p->last_op];
+	op = prv_append_op(p, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return NULL;
-	p->ops[p->len] = p->ops[p->len - 1];
-	op = &p->ops[p->len++];
+
+	*op = *src;
+	op->next = SIZE_MAX;
+
 	return &op->op.instr;
 }
 
@@ -278,6 +392,32 @@ static size_t prv_add_data_imm_ldr(subtilis_arm_program_t *p,
 		return 0;
 
 	instr = subtilis_arm_program_add_instr(p, SUBTILIS_ARM_INSTR_LDRC, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return 0;
+
+	ldrc = &instr->operands.ldrc;
+	ldrc->ccode = ccode;
+	ldrc->dest = dest;
+	ldrc->label = label;
+	return label;
+}
+
+static size_t prv_insert_data_imm_ldr(subtilis_arm_program_t *p,
+				      subtilis_arm_op_t *current,
+				      subtilis_arm_ccode_type_t ccode,
+				      subtilis_arm_reg_t dest, int32_t op2,
+				      subtilis_error_t *err)
+{
+	subtilis_arm_ldrc_instr_t *ldrc;
+	subtilis_arm_instr_t *instr;
+	size_t label = p->label_counter++;
+
+	prv_add_constant(p, label, (uint32_t)op2, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return 0;
+
+	instr = subtilis_arm_program_insert_instr(p, current,
+						  SUBTILIS_ARM_INSTR_LDRC, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return 0;
 
@@ -574,6 +714,132 @@ void subtilis_arm_stran_imm(subtilis_arm_program_t *p,
 	stran->write_back = false;
 }
 
+void subtilis_arm_insert_push(subtilis_arm_program_t *p,
+			      subtilis_arm_op_t *current,
+			      subtilis_arm_ccode_type_t ccode, size_t reg_num,
+			      subtilis_error_t *err)
+{
+	subtilis_arm_reg_t dest;
+	subtilis_arm_reg_t base;
+	subtilis_arm_instr_t *instr;
+	subtilis_arm_stran_instr_t *stran;
+
+	dest.num = 0;
+	dest.type = SUBTILIS_ARM_REG_FIXED;
+
+	base.num = 13;
+	base.type = SUBTILIS_ARM_REG_FIXED;
+
+	instr = subtilis_arm_program_insert_instr(p, current,
+						  SUBTILIS_ARM_INSTR_LDR, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+	stran = &instr->operands.stran;
+	stran->ccode = ccode;
+	stran->dest = dest;
+	stran->base = base;
+	stran->offset.type = SUBTILIS_ARM_OP2_I32;
+	stran->offset.op.integer = -4;
+	stran->pre_indexed = false;
+	stran->write_back = true;
+}
+
+void subtilis_arm_insert_pop(subtilis_arm_program_t *p,
+			     subtilis_arm_op_t *current,
+			     subtilis_arm_ccode_type_t ccode, size_t reg_num,
+			     subtilis_error_t *err)
+{
+	subtilis_arm_reg_t dest;
+	subtilis_arm_reg_t base;
+	subtilis_arm_instr_t *instr;
+	subtilis_arm_stran_instr_t *stran;
+
+	dest.num = 0;
+	dest.type = SUBTILIS_ARM_REG_FIXED;
+
+	base.num = 13;
+	base.type = SUBTILIS_ARM_REG_FIXED;
+
+	instr = subtilis_arm_program_insert_instr(p, current,
+						  SUBTILIS_ARM_INSTR_STR, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+	stran = &instr->operands.stran;
+	stran->ccode = ccode;
+	stran->dest = dest;
+	stran->base = base;
+	stran->offset.type = SUBTILIS_ARM_OP2_I32;
+	stran->offset.op.integer = 4;
+	stran->pre_indexed = false;
+	stran->write_back = true;
+}
+
+/* clang-format off */
+void subtilis_arm_insert_stran_spill_imm(subtilis_arm_program_t *p,
+					 subtilis_arm_op_t *current,
+					 subtilis_arm_instr_type_t itype,
+					 subtilis_arm_ccode_type_t ccode,
+					 subtilis_arm_reg_t dest,
+					 subtilis_arm_reg_t base,
+					 subtilis_arm_reg_t spill_reg,
+					 int32_t offset, subtilis_error_t *err)
+/* clang-format on */
+{
+	subtilis_arm_op2_t op2;
+	subtilis_arm_instr_t *instr;
+	subtilis_arm_stran_instr_t *stran;
+
+	op2.op.reg = spill_reg;
+	(void)prv_insert_data_imm_ldr(p, current, ccode, op2.op.reg, offset,
+				      err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+	op2.type = SUBTILIS_ARM_OP2_REG;
+
+	instr = subtilis_arm_program_insert_instr(p, current, itype, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+	stran = &instr->operands.stran;
+	stran->ccode = ccode;
+	stran->dest = dest;
+	stran->base = base;
+	stran->offset = op2;
+	stran->pre_indexed = true;
+	stran->write_back = false;
+}
+
+void subtilis_arm_insert_stran_imm(subtilis_arm_program_t *p,
+				   subtilis_arm_op_t *current,
+				   subtilis_arm_instr_type_t itype,
+				   subtilis_arm_ccode_type_t ccode,
+				   subtilis_arm_reg_t dest,
+				   subtilis_arm_reg_t base, int32_t offset,
+				   subtilis_error_t *err)
+{
+	subtilis_arm_op2_t op2;
+	subtilis_arm_instr_t *instr;
+	subtilis_arm_stran_instr_t *stran;
+
+	if (offset > 4095 || offset < -4095) {
+		subtilis_error_set_asssertion_failed(err);
+		return;
+	}
+
+	op2.type = SUBTILIS_ARM_OP2_I32;
+	op2.op.integer = offset;
+
+	instr = subtilis_arm_program_insert_instr(p, current, itype, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+	stran = &instr->operands.stran;
+	stran->ccode = ccode;
+	stran->dest = dest;
+	stran->base = base;
+	stran->offset = op2;
+	stran->pre_indexed = true;
+	stran->write_back = false;
+}
+
 void subtilis_arm_cmp_imm(subtilis_arm_program_t *p,
 			  subtilis_arm_ccode_type_t ccode,
 			  subtilis_arm_reg_t op1, int32_t op2,
@@ -687,7 +953,8 @@ static void prv_dump_op2(subtilis_arm_op2_t *op2)
 	}
 }
 
-static void prv_dump_mov_instr(void *user_data, subtilis_arm_instr_type_t type,
+static void prv_dump_mov_instr(void *user_data, subtilis_arm_op_t *op,
+			       subtilis_arm_instr_type_t type,
 			       subtilis_arm_data_instr_t *instr,
 			       subtilis_error_t *err)
 {
@@ -701,7 +968,8 @@ static void prv_dump_mov_instr(void *user_data, subtilis_arm_instr_type_t type,
 	printf("\n");
 }
 
-static void prv_dump_data_instr(void *user_data, subtilis_arm_instr_type_t type,
+static void prv_dump_data_instr(void *user_data, subtilis_arm_op_t *op,
+				subtilis_arm_instr_type_t type,
 				subtilis_arm_data_instr_t *instr,
 				subtilis_error_t *err)
 {
@@ -715,7 +983,7 @@ static void prv_dump_data_instr(void *user_data, subtilis_arm_instr_type_t type,
 	printf("\n");
 }
 
-static void prv_dump_stran_instr(void *user_data,
+static void prv_dump_stran_instr(void *user_data, subtilis_arm_op_t *op,
 				 subtilis_arm_instr_type_t type,
 				 subtilis_arm_stran_instr_t *instr,
 				 subtilis_error_t *err)
@@ -737,7 +1005,7 @@ static void prv_dump_stran_instr(void *user_data,
 	printf("\n");
 }
 
-static void prv_dump_mtran_instr(void *user_data,
+static void prv_dump_mtran_instr(void *user_data, subtilis_arm_op_t *op,
 				 subtilis_arm_instr_type_t type,
 				 subtilis_arm_mtran_instr_t *instr,
 				 subtilis_error_t *err)
@@ -745,7 +1013,8 @@ static void prv_dump_mtran_instr(void *user_data,
 	subtilis_error_set_asssertion_failed(err);
 }
 
-static void prv_dump_br_instr(void *user_data, subtilis_arm_instr_type_t type,
+static void prv_dump_br_instr(void *user_data, subtilis_arm_op_t *op,
+			      subtilis_arm_instr_type_t type,
 			      subtilis_arm_br_instr_t *instr,
 			      subtilis_error_t *err)
 {
@@ -755,7 +1024,8 @@ static void prv_dump_br_instr(void *user_data, subtilis_arm_instr_type_t type,
 	printf(" label_%zu\n", instr->label);
 }
 
-static void prv_dump_swi_instr(void *user_data, subtilis_arm_instr_type_t type,
+static void prv_dump_swi_instr(void *user_data, subtilis_arm_op_t *op,
+			       subtilis_arm_instr_type_t type,
 			       subtilis_arm_swi_instr_t *instr,
 			       subtilis_error_t *err)
 {
@@ -765,7 +1035,8 @@ static void prv_dump_swi_instr(void *user_data, subtilis_arm_instr_type_t type,
 	printf(" &%zx\n", instr->code);
 }
 
-static void prv_dump_ldrc_instr(void *user_data, subtilis_arm_instr_type_t type,
+static void prv_dump_ldrc_instr(void *user_data, subtilis_arm_op_t *op,
+				subtilis_arm_instr_type_t type,
 				subtilis_arm_ldrc_instr_t *instr,
 				subtilis_error_t *err)
 {
@@ -775,7 +1046,8 @@ static void prv_dump_ldrc_instr(void *user_data, subtilis_arm_instr_type_t type,
 	printf(" R%zu, label_%zu\n", instr->dest.num, instr->label);
 }
 
-static void prv_dump_cmp_instr(void *user_data, subtilis_arm_instr_type_t type,
+static void prv_dump_cmp_instr(void *user_data, subtilis_arm_op_t *op,
+			       subtilis_arm_instr_type_t type,
 			       subtilis_arm_data_instr_t *instr,
 			       subtilis_error_t *err)
 {
@@ -787,7 +1059,8 @@ static void prv_dump_cmp_instr(void *user_data, subtilis_arm_instr_type_t type,
 	printf("\n");
 }
 
-static void prv_dump_label(void *user_data, size_t label, subtilis_error_t *err)
+static void prv_dump_label(void *user_data, subtilis_arm_op_t *op, size_t label,
+			   subtilis_error_t *err)
 {
 	printf(".label_%zu\n", label);
 }

--- a/arm_core.h
+++ b/arm_core.h
@@ -210,7 +210,6 @@ struct subtilis_arm_program_t_ {
 	size_t max_len;
 	subtilis_arm_op_t *ops;
 	size_t globals;
-	size_t *op_order;
 	subtilis_arm_constant_t *constants;
 	size_t constant_count;
 	size_t max_constants;

--- a/arm_core_test.c
+++ b/arm_core_test.c
@@ -110,7 +110,8 @@ fail:
 	return 1;
 }
 
-static subtilis_arm_program_t *prv_add_imm(int32_t num,
+static subtilis_arm_program_t *prv_add_imm(subtilis_arm_op_pool_t *pool,
+					   int32_t num,
 					   subtilis_arm_instr_type_t itype,
 					   subtilis_arm_instr_type_t alt_type,
 					   subtilis_error_t *err)
@@ -119,7 +120,7 @@ static subtilis_arm_program_t *prv_add_imm(int32_t num,
 	subtilis_arm_reg_t dest;
 	subtilis_arm_reg_t op1;
 
-	p = subtilis_arm_program_new(0, 0, 0, err);
+	p = subtilis_arm_program_new(pool, 0, 0, 0, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return NULL;
 
@@ -160,7 +161,7 @@ static int prv_check_imm(subtilis_arm_program_t *p,
 	}
 
 	for (i = 0; i < count; i++) {
-		op = &p->ops[i];
+		op = &p->pool->ops[i];
 		if (op->type != SUBTILIS_OP_INSTR) {
 			fprintf(stderr, "Expected instruction %d, found %d\n",
 				SUBTILIS_OP_INSTR, op->type);
@@ -189,13 +190,18 @@ static int prv_test_arm_add_data_1_imm(void)
 	subtilis_arm_program_t *p = NULL;
 	subtilis_error_t err;
 	uint32_t nums[] = {127};
-
-	printf("arm_add_data_imm");
+	subtilis_arm_op_pool_t *pool;
 
 	subtilis_error_init(&err);
 
-	p = prv_add_imm(127, SUBTILIS_ARM_INSTR_ADD, SUBTILIS_ARM_INSTR_SUB,
-			&err);
+	printf("arm_add_data_imm");
+
+	pool = subtilis_arm_op_pool_new(&err);
+	if (err.type != SUBTILIS_ERROR_OK)
+		goto fail;
+
+	p = prv_add_imm(pool, 127, SUBTILIS_ARM_INSTR_ADD,
+			SUBTILIS_ARM_INSTR_SUB, &err);
 	if (err.type != SUBTILIS_ERROR_OK)
 		goto fail;
 
@@ -203,12 +209,14 @@ static int prv_test_arm_add_data_1_imm(void)
 		goto fail;
 
 	subtilis_arm_program_delete(p);
+	subtilis_arm_op_pool_delete(pool);
 
 	printf(": [OK]\n");
 	return 0;
 
 fail:
 	subtilis_arm_program_delete(p);
+	subtilis_arm_op_pool_delete(pool);
 
 	printf(": [FAIL]\n");
 	return 1;
@@ -219,13 +227,18 @@ static int prv_test_arm_add_data_2_imm(void)
 	subtilis_arm_program_t *p = NULL;
 	subtilis_error_t err;
 	uint32_t nums[] = {0xc01, 1};
+	subtilis_arm_op_pool_t *pool;
 
 	printf("arm_add_data_2_imm");
 
 	subtilis_error_init(&err);
 
-	p = prv_add_imm(257, SUBTILIS_ARM_INSTR_ADD, SUBTILIS_ARM_INSTR_SUB,
-			&err);
+	pool = subtilis_arm_op_pool_new(&err);
+	if (err.type != SUBTILIS_ERROR_OK)
+		goto fail;
+
+	p = prv_add_imm(pool, 257, SUBTILIS_ARM_INSTR_ADD,
+			SUBTILIS_ARM_INSTR_SUB, &err);
 	if (err.type != SUBTILIS_ERROR_OK)
 		goto fail;
 
@@ -233,12 +246,14 @@ static int prv_test_arm_add_data_2_imm(void)
 		goto fail;
 
 	subtilis_arm_program_delete(p);
+	subtilis_arm_op_pool_delete(pool);
 
 	printf(": [OK]\n");
 	return 0;
 
 fail:
 	subtilis_arm_program_delete(p);
+	subtilis_arm_op_pool_delete(pool);
 
 	printf(": [FAIL]\n");
 	return 1;
@@ -249,12 +264,17 @@ static int prv_test_arm_add_data_neg_imm(void)
 	subtilis_arm_program_t *p = NULL;
 	subtilis_error_t err;
 	uint32_t nums[] = {0xc01};
+	subtilis_arm_op_pool_t *pool;
 
 	printf("arm_add_data_neg_imm");
 
 	subtilis_error_init(&err);
 
-	p = prv_add_imm(0xffffff00, SUBTILIS_ARM_INSTR_ADD,
+	pool = subtilis_arm_op_pool_new(&err);
+	if (err.type != SUBTILIS_ERROR_OK)
+		goto fail;
+
+	p = prv_add_imm(pool, 0xffffff00, SUBTILIS_ARM_INSTR_ADD,
 			SUBTILIS_ARM_INSTR_SUB, &err);
 	if (err.type != SUBTILIS_ERROR_OK)
 		goto fail;
@@ -263,12 +283,14 @@ static int prv_test_arm_add_data_neg_imm(void)
 		goto fail;
 
 	subtilis_arm_program_delete(p);
+	subtilis_arm_op_pool_delete(pool);
 
 	printf(": [OK]\n");
 	return 0;
 
 fail:
 	subtilis_arm_program_delete(p);
+	subtilis_arm_op_pool_delete(pool);
 
 	printf(": [FAIL]\n");
 	return 1;
@@ -279,12 +301,17 @@ static int prv_test_arm_add_data_neg_2_imm(void)
 	subtilis_arm_program_t *p = NULL;
 	subtilis_error_t err;
 	uint32_t nums[] = {0x8ff, 0x10};
+	subtilis_arm_op_pool_t *pool;
 
 	printf("arm_add_data_neg_2_imm");
 
 	subtilis_error_init(&err);
 
-	p = prv_add_imm(0xff00fff0, SUBTILIS_ARM_INSTR_ADD,
+	pool = subtilis_arm_op_pool_new(&err);
+	if (err.type != SUBTILIS_ERROR_OK)
+		goto fail;
+
+	p = prv_add_imm(pool, 0xff00fff0, SUBTILIS_ARM_INSTR_ADD,
 			SUBTILIS_ARM_INSTR_SUB, &err);
 	if (err.type != SUBTILIS_ERROR_OK)
 		goto fail;
@@ -293,12 +320,14 @@ static int prv_test_arm_add_data_neg_2_imm(void)
 		goto fail;
 
 	subtilis_arm_program_delete(p);
+	subtilis_arm_op_pool_delete(pool);
 
 	printf(": [OK]\n");
 	return 0;
 
 fail:
 	subtilis_arm_program_delete(p);
+	subtilis_arm_op_pool_delete(pool);
 
 	printf(": [FAIL]\n");
 	return 1;
@@ -310,12 +339,17 @@ static int prv_test_arm_add_data_ldr_imm(void)
 	subtilis_error_t err;
 	subtilis_arm_op_t *op;
 	subtilis_arm_instr_t *instr;
+	subtilis_arm_op_pool_t *pool;
 
 	printf("arm_add_data_ldr_imm");
 
 	subtilis_error_init(&err);
 
-	p = prv_add_imm(0xf0f0f0f0, SUBTILIS_ARM_INSTR_ADD,
+	pool = subtilis_arm_op_pool_new(&err);
+	if (err.type != SUBTILIS_ERROR_OK)
+		goto fail;
+
+	p = prv_add_imm(pool, 0xf0f0f0f0, SUBTILIS_ARM_INSTR_ADD,
 			SUBTILIS_ARM_INSTR_SUB, &err);
 	if (err.type != SUBTILIS_ERROR_OK)
 		goto fail;
@@ -331,7 +365,7 @@ static int prv_test_arm_add_data_ldr_imm(void)
 		return 1;
 	}
 
-	op = &p->ops[0];
+	op = &p->pool->ops[0];
 	if (op->type != SUBTILIS_OP_INSTR) {
 		fprintf(stderr, "Expected instruction %d, found %d\n",
 			SUBTILIS_OP_INSTR, op->type);
@@ -345,7 +379,7 @@ static int prv_test_arm_add_data_ldr_imm(void)
 		return 1;
 	}
 
-	op = &p->ops[1];
+	op = &p->pool->ops[1];
 	if (op->type != SUBTILIS_OP_INSTR) {
 		fprintf(stderr, "Expected instruction %d, found %d\n",
 			SUBTILIS_OP_INSTR, op->type);
@@ -366,12 +400,14 @@ static int prv_test_arm_add_data_ldr_imm(void)
 	}
 
 	subtilis_arm_program_delete(p);
+	subtilis_arm_op_pool_delete(pool);
 
 	printf(": [OK]\n");
 	return 0;
 
 fail:
 	subtilis_arm_program_delete(p);
+	subtilis_arm_op_pool_delete(pool);
 
 	printf(": [FAIL]\n");
 	return 1;

--- a/arm_reg_alloc.c
+++ b/arm_reg_alloc.c
@@ -1,0 +1,827 @@
+/*
+ * Copyright (c) 2017 Mark Ryan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <limits.h>
+#include <stdlib.h>
+
+#include "arm_reg_alloc.h"
+#include "arm_walker.h"
+
+#define SUBTILIS_ARM_REG_MAX_REGS 11
+
+struct subtilis_arm_reg_class_t_ {
+	size_t phys_to_virt[SUBTILIS_ARM_REG_MAX_REGS];
+	int next[SUBTILIS_ARM_REG_MAX_REGS];
+	size_t vr_reg_count;
+	int32_t *spilt_regs;
+	size_t *spill_stack;
+	size_t spill_top;
+	size_t spill_max;
+};
+
+typedef struct subtilis_arm_reg_class_t_ subtilis_arm_reg_class_t;
+
+struct subtilis_dist_data_t_ {
+	size_t reg_num;
+	int last_used;
+};
+
+typedef struct subtilis_dist_data_t_ subtilis_dist_data_t;
+
+struct subtilis_arm_reg_ud_t_ {
+	subtilis_arm_reg_class_t int_regs;
+	subtilis_arm_program_t *arm_p;
+	size_t instr_count;
+	subtlis_arm_walker_t dist_walker;
+	subtilis_dist_data_t dist_data;
+};
+
+typedef struct subtilis_arm_reg_ud_t_ subtilis_arm_reg_ud_t;
+
+static void prv_init_int_regs(subtilis_arm_reg_class_t *regs, size_t reg_count,
+			      subtilis_error_t *err)
+{
+	size_t i;
+
+	regs->spilt_regs = malloc(reg_count * sizeof(int32_t));
+	if (!regs->spilt_regs) {
+		subtilis_error_set_oom(err);
+		return;
+	}
+	regs->spill_stack = malloc(reg_count * sizeof(size_t));
+	if (!regs->spill_stack) {
+		free(regs->spilt_regs);
+		subtilis_error_set_oom(err);
+		return;
+	}
+
+	for (i = 0; i < reg_count; i++) {
+		regs->spilt_regs[i] = -1;
+		regs->spill_stack[i] = i * 4;
+	}
+	regs->spill_top = 0;
+	regs->spill_max = 0;
+	regs->vr_reg_count = reg_count;
+
+	for (i = 0; i < SUBTILIS_ARM_REG_MAX_REGS; i++) {
+		regs->next[i] = -1;
+		regs->phys_to_virt[i] = INT_MAX;
+	}
+}
+
+static void prv_free_int_regs(subtilis_arm_reg_class_t *regs)
+{
+	if (regs) {
+		free(regs->spill_stack);
+		free(regs->spilt_regs);
+	}
+}
+
+static void prv_dist_handle_op2(subtilis_dist_data_t *ud,
+				subtilis_arm_op2_t *op2, subtilis_error_t *err)
+{
+	if (op2->type == SUBTILIS_ARM_OP2_REG) {
+		if (op2->op.reg.num == ud->reg_num) {
+			subtilis_error_set_walker_failed(err);
+			return;
+		}
+	} else if (op2->type == SUBTILIS_ARM_OP2_SHIFTED) {
+		if (op2->op.shift.reg.num == ud->reg_num) {
+			subtilis_error_set_walker_failed(err);
+			return;
+		}
+	}
+	ud->last_used++;
+}
+
+static void prv_dist_mov_instr(void *user_data, subtilis_arm_op_t *op,
+			       subtilis_arm_instr_type_t type,
+			       subtilis_arm_data_instr_t *instr,
+			       subtilis_error_t *err)
+{
+	subtilis_dist_data_t *ud = user_data;
+
+	if (instr->dest.num == ud->reg_num) {
+		ud->last_used = -1;
+		subtilis_error_set_walker_failed(err);
+		return;
+	}
+
+	prv_dist_handle_op2(ud, &instr->op2, err);
+}
+
+static void prv_dist_data_instr(void *user_data, subtilis_arm_op_t *op,
+				subtilis_arm_instr_type_t type,
+				subtilis_arm_data_instr_t *instr,
+				subtilis_error_t *err)
+{
+	subtilis_dist_data_t *ud = user_data;
+
+	if (instr->dest.num == ud->reg_num) {
+		ud->last_used = -1;
+		subtilis_error_set_walker_failed(err);
+		return;
+	}
+
+	if (instr->op1.num == ud->reg_num) {
+		subtilis_error_set_walker_failed(err);
+		return;
+	}
+
+	prv_dist_handle_op2(ud, &instr->op2, err);
+}
+
+static void prv_dist_stran_instr(void *user_data, subtilis_arm_op_t *op,
+				 subtilis_arm_instr_type_t type,
+				 subtilis_arm_stran_instr_t *instr,
+				 subtilis_error_t *err)
+{
+	subtilis_dist_data_t *ud = user_data;
+
+	if (type == SUBTILIS_ARM_INSTR_LDR) {
+		if (instr->dest.num == ud->reg_num) {
+			ud->last_used = -1;
+			subtilis_error_set_walker_failed(err);
+			return;
+		}
+	} else {
+		if (instr->dest.num == ud->reg_num) {
+			subtilis_error_set_walker_failed(err);
+			return;
+		}
+	}
+
+	if (instr->base.num == ud->reg_num) {
+		subtilis_error_set_walker_failed(err);
+		return;
+	}
+
+	prv_dist_handle_op2(ud, &instr->offset, err);
+}
+
+static void prv_dist_mtran_instr(void *user_data, subtilis_arm_op_t *op,
+				 subtilis_arm_instr_type_t type,
+				 subtilis_arm_mtran_instr_t *instr,
+				 subtilis_error_t *err)
+{
+	subtilis_error_set_asssertion_failed(err);
+}
+
+static void prv_dist_br_instr(void *user_data, subtilis_arm_op_t *op,
+			      subtilis_arm_instr_type_t type,
+			      subtilis_arm_br_instr_t *instr,
+			      subtilis_error_t *err)
+{
+	subtilis_dist_data_t *ud = user_data;
+
+	ud->last_used++;
+}
+
+static void prv_dist_swi_instr(void *user_data, subtilis_arm_op_t *op,
+			       subtilis_arm_instr_type_t type,
+			       subtilis_arm_swi_instr_t *instr,
+			       subtilis_error_t *err)
+{
+	subtilis_dist_data_t *ud = user_data;
+
+	if ((1 << ud->reg_num) & instr->reg_mask) {
+		ud->last_used = -1;
+		subtilis_error_set_walker_failed(err);
+		return;
+	}
+
+	ud->last_used++;
+}
+
+static void prv_dist_ldrc_instr(void *user_data, subtilis_arm_op_t *op,
+				subtilis_arm_instr_type_t type,
+				subtilis_arm_ldrc_instr_t *instr,
+				subtilis_error_t *err)
+{
+	subtilis_dist_data_t *ud = user_data;
+
+	if (instr->dest.num == ud->reg_num) {
+		ud->last_used = -1;
+		subtilis_error_set_walker_failed(err);
+		return;
+	}
+
+	ud->last_used++;
+}
+
+static void prv_dist_cmp_instr(void *user_data, subtilis_arm_op_t *op,
+			       subtilis_arm_instr_type_t type,
+			       subtilis_arm_data_instr_t *instr,
+			       subtilis_error_t *err)
+{
+	subtilis_dist_data_t *ud = user_data;
+
+	if (instr->op1.num == ud->reg_num) {
+		subtilis_error_set_walker_failed(err);
+		return;
+	}
+
+	prv_dist_handle_op2(ud, &instr->op2, err);
+}
+
+static void prv_dist_label(void *user_data, subtilis_arm_op_t *op, size_t label,
+			   subtilis_error_t *err)
+{
+	subtilis_dist_data_t *ud = user_data;
+
+	ud->last_used++;
+}
+
+static void prv_init_arm_reg_ud(subtilis_arm_reg_ud_t *ud,
+				subtilis_arm_program_t *arm_p,
+				subtilis_error_t *err)
+{
+	prv_init_int_regs(&ud->int_regs, arm_p->reg_counter, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	ud->instr_count = 0;
+	ud->arm_p = arm_p;
+
+	ud->dist_walker.user_data = &ud->dist_data;
+	ud->dist_walker.label_fn = prv_dist_label;
+	ud->dist_walker.data_fn = prv_dist_data_instr;
+	ud->dist_walker.cmp_fn = prv_dist_cmp_instr;
+	ud->dist_walker.mov_fn = prv_dist_mov_instr;
+	ud->dist_walker.stran_fn = prv_dist_stran_instr;
+	ud->dist_walker.mtran_fn = prv_dist_mtran_instr;
+	ud->dist_walker.br_fn = prv_dist_br_instr;
+	ud->dist_walker.swi_fn = prv_dist_swi_instr;
+	ud->dist_walker.ldrc_fn = prv_dist_ldrc_instr;
+}
+
+static int prv_calculate_dist(subtilis_arm_reg_ud_t *ud, size_t reg_num,
+			      subtilis_arm_op_t *op)
+{
+	subtilis_error_t err;
+
+	subtilis_error_init(&err);
+
+	if (op->next == SIZE_MAX)
+		return -1;
+
+	op = &ud->arm_p->pool->ops[op->next];
+
+	ud->dist_data.reg_num = reg_num;
+	ud->dist_data.last_used = ud->instr_count + 1;
+
+	subtilis_arm_walk_from(ud->arm_p, &ud->dist_walker, op, &err);
+	if (err.type != SUBTILIS_ERROR_OK)
+		return ud->dist_data.last_used;
+	else
+		return -1;
+}
+
+static void prv_free_arm_reg_ud(subtilis_arm_reg_ud_t *ud)
+{
+	if (ud)
+		prv_free_int_regs(&ud->int_regs);
+}
+
+static size_t prv_virt_to_phys(subtilis_arm_reg_class_t *regs,
+			       subtilis_arm_reg_t *reg)
+{
+	size_t i;
+	size_t retval = INT_MAX;
+
+	for (i = 0; i < SUBTILIS_ARM_REG_MAX_REGS; i++) {
+		if (regs->phys_to_virt[i] == reg->num)
+			return i;
+	}
+
+	return retval;
+}
+
+static void prv_load_spilled_reg(subtilis_arm_program_t *arm_p,
+				 subtilis_arm_op_t *current,
+				 subtilis_arm_reg_class_t *regs,
+				 subtilis_arm_reg_t virt,
+				 subtilis_arm_reg_t phys, subtilis_error_t *err)
+{
+	subtilis_arm_reg_t base;
+	int32_t offset = regs->spilt_regs[virt.num];
+
+	if (offset == INT_MAX) {
+		subtilis_error_set_asssertion_failed(err);
+		return;
+	}
+
+	if (regs->spill_top == 0) {
+		subtilis_error_set_asssertion_failed(err);
+		return;
+	}
+
+	offset += arm_p->globals;
+
+	base.type = SUBTILIS_ARM_REG_FIXED;
+	base.num = 12;
+	if (offset > 4095 || offset < -4095) {
+		subtilis_arm_insert_stran_spill_imm(
+		    arm_p, current, SUBTILIS_ARM_INSTR_LDR,
+		    SUBTILIS_ARM_CCODE_AL, phys, base, phys, offset, err);
+		if (err->type != SUBTILIS_ERROR_OK)
+			return;
+	} else {
+		subtilis_arm_insert_stran_imm(
+		    arm_p, current, SUBTILIS_ARM_INSTR_LDR,
+		    SUBTILIS_ARM_CCODE_AL, phys, base, offset, err);
+	}
+
+	/* TODO need to update next */
+
+	regs->phys_to_virt[phys.num] = virt.num;
+	regs->spilt_regs[virt.num] = INT_MAX;
+	regs->spill_top--;
+	regs->spill_stack[regs->spill_top] = offset;
+	regs->next[phys.num] = -1;
+}
+
+static void prv_spill_reg(subtilis_arm_program_t *arm_p,
+			  subtilis_arm_op_t *current, size_t assigned,
+			  subtilis_arm_reg_class_t *regs,
+			  subtilis_arm_reg_t reg, subtilis_error_t *err)
+{
+	size_t i;
+	subtilis_arm_reg_t spill_reg;
+	int32_t offset;
+	subtilis_arm_reg_t base;
+
+	if (regs->spill_top == regs->vr_reg_count) {
+		subtilis_error_set_asssertion_failed(err);
+		return;
+	}
+
+	offset = (int32_t)regs->spill_stack[regs->spill_top++] + arm_p->globals;
+	if (regs->spill_max < regs->spill_top)
+		regs->spill_max = regs->spill_top;
+
+	regs->spilt_regs[assigned] = offset;
+
+	base.type = SUBTILIS_ARM_REG_FIXED;
+	base.num = 12;
+	if (offset > 4095 || offset < -4095) {
+		for (i = 0; i < SUBTILIS_ARM_REG_MAX_REGS; i++)
+			if ((regs->phys_to_virt[i] == INT_MAX) &&
+			    (i != reg.num))
+				break;
+
+		spill_reg.type = SUBTILIS_ARM_REG_FIXED;
+		if (i == SUBTILIS_ARM_REG_MAX_REGS) {
+			subtilis_arm_insert_push(arm_p, current,
+						 SUBTILIS_ARM_CCODE_AL, 0, err);
+			if (err->type != SUBTILIS_ERROR_OK)
+				return;
+			spill_reg.num = 0;
+		} else {
+			spill_reg.num = i;
+		}
+		subtilis_arm_insert_stran_spill_imm(
+		    arm_p, current, SUBTILIS_ARM_INSTR_STR,
+		    SUBTILIS_ARM_CCODE_AL, reg, base, spill_reg, offset, err);
+		if (err->type != SUBTILIS_ERROR_OK)
+			return;
+
+		if (i == SUBTILIS_ARM_REG_MAX_REGS) {
+			subtilis_arm_insert_pop(arm_p, current,
+						SUBTILIS_ARM_CCODE_AL, 0, err);
+			if (err->type != SUBTILIS_ERROR_OK)
+				return;
+		}
+	} else {
+		subtilis_arm_insert_stran_imm(
+		    arm_p, current, SUBTILIS_ARM_INSTR_STR,
+		    SUBTILIS_ARM_CCODE_AL, reg, base, offset, err);
+	}
+
+	/* TODO need to update next */
+}
+
+static void prv_allocate_fixed(subtilis_arm_program_t *arm_p,
+			       subtilis_arm_op_t *current,
+			       subtilis_arm_reg_class_t *regs,
+			       subtilis_arm_reg_t *reg, subtilis_error_t *err)
+{
+	size_t assigned;
+
+	if (reg->num >= SUBTILIS_ARM_REG_MAX_REGS)
+		return;
+
+	assigned = regs->phys_to_virt[reg->num];
+	if (assigned != INT_MAX) {
+		prv_spill_reg(arm_p, current, assigned, regs, *reg, err);
+		if (err->type != SUBTILIS_ERROR_OK)
+			return;
+	}
+}
+
+static void prv_allocate_floating(subtilis_arm_program_t *arm_p,
+				  subtilis_arm_op_t *current,
+				  subtilis_arm_reg_class_t *regs,
+				  subtilis_arm_reg_t *reg,
+				  subtilis_error_t *err)
+{
+	subtilis_arm_reg_t target_reg;
+	size_t next = SUBTILIS_ARM_REG_MAX_REGS;
+	size_t max_next = -1;
+	int i;
+
+	/* Virtual register is not already assigned. */
+
+	for (i = SUBTILIS_ARM_REG_MAX_REGS - 1; i >= 0; i--)
+		if (regs->phys_to_virt[i] == INT_MAX)
+			break;
+
+	target_reg.type = SUBTILIS_ARM_REG_FIXED;
+	if (i >= 0) {
+		target_reg.num = (size_t)i;
+	} else {
+		/* No free physical regs.  Need to spill. */
+
+		for (i = 0; i < SUBTILIS_ARM_REG_MAX_REGS; i++)
+			if (regs->next[i] > max_next) {
+				max_next = regs->next[i];
+				next = i;
+			}
+		if (next == SUBTILIS_ARM_REG_MAX_REGS) {
+			subtilis_error_set_asssertion_failed(err);
+			return;
+		}
+		target_reg.num = next;
+		prv_spill_reg(arm_p, current, next, regs, target_reg, err);
+		if (err->type != SUBTILIS_ERROR_OK)
+			return;
+	}
+
+	*reg = target_reg;
+}
+
+static void prv_allocate(subtilis_arm_program_t *arm_p,
+			 subtilis_arm_op_t *current,
+			 subtilis_arm_reg_class_t *regs,
+			 subtilis_arm_reg_t *reg, subtilis_error_t *err)
+{
+	size_t virt_num = reg->num;
+
+	if (reg->type == SUBTILIS_ARM_REG_FIXED)
+		prv_allocate_fixed(arm_p, current, regs, reg, err);
+	else
+		prv_allocate_floating(arm_p, current, regs, reg, err);
+
+	regs->phys_to_virt[reg->num] = virt_num;
+}
+
+static void prv_ensure(subtilis_arm_program_t *arm_p,
+		       subtilis_arm_op_t *current,
+		       subtilis_arm_reg_class_t *regs, subtilis_arm_reg_t *reg,
+		       subtilis_error_t *err)
+{
+	size_t assigned;
+	subtilis_arm_reg_t target_reg;
+
+	if (reg->type == SUBTILIS_ARM_REG_FIXED) {
+		/*
+		 * Register has fixed use and is unavailable to user's code
+		 * Physical register has already been allocated, e.g., r12, r13
+		 */
+		if (reg->num >= SUBTILIS_ARM_REG_MAX_REGS)
+			return;
+
+		assigned = regs->phys_to_virt[reg->num];
+		if (assigned != reg->num) {
+			prv_allocate_fixed(arm_p, current, regs, reg, err);
+			if (err->type != SUBTILIS_ERROR_OK)
+				return;
+			prv_load_spilled_reg(arm_p, current, regs, *reg, *reg,
+					     err);
+			if (err->type != SUBTILIS_ERROR_OK)
+				return;
+		}
+	} else {
+		assigned = prv_virt_to_phys(regs, reg);
+		if (assigned != INT_MAX) {
+			reg->num = assigned;
+			reg->type = SUBTILIS_ARM_REG_FIXED;
+		} else {
+			prv_allocate_floating(arm_p, current, regs, &target_reg,
+					      err);
+			if (err->type != SUBTILIS_ERROR_OK)
+				return;
+			prv_load_spilled_reg(arm_p, current, regs, *reg,
+					     target_reg, err);
+			if (err->type != SUBTILIS_ERROR_OK)
+				return;
+			*reg = target_reg;
+		}
+	}
+}
+
+static void prv_alloc_label(void *user_data, subtilis_arm_op_t *op,
+			    size_t label, subtilis_error_t *err)
+{
+	subtilis_arm_reg_ud_t *ud = user_data;
+
+	ud->instr_count++;
+}
+
+static subtilis_arm_reg_t *prv_ensure_op2(subtilis_arm_reg_ud_t *ud,
+					  subtilis_arm_op_t *op,
+					  subtilis_arm_op2_t *op2,
+					  int *dist_op2, subtilis_error_t *err)
+{
+	size_t vreg_op2;
+	subtilis_arm_reg_t *reg = NULL;
+
+	if (op2->type == SUBTILIS_ARM_OP2_I32)
+		return NULL;
+
+	if (op2->type == SUBTILIS_ARM_OP2_REG)
+		reg = &op2->op.reg;
+	else if (op2->type == SUBTILIS_ARM_OP2_SHIFTED)
+		reg = &op2->op.shift.reg;
+	vreg_op2 = reg->num;
+	prv_ensure(ud->arm_p, op, &ud->int_regs, reg, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return NULL;
+
+	*dist_op2 = prv_calculate_dist(ud, vreg_op2, op);
+	if (*dist_op2 == -1)
+		ud->int_regs.phys_to_virt[reg->num] = INT_MAX;
+
+	return reg;
+}
+
+static void prv_allocate_dest(subtilis_arm_reg_ud_t *ud, subtilis_arm_op_t *op,
+			      subtilis_arm_reg_t *dest, subtilis_error_t *err)
+{
+	int dist_dest;
+	size_t vreg_dest = dest->num;
+
+	prv_allocate(ud->arm_p, op, &ud->int_regs, dest, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+	dist_dest = prv_calculate_dist(ud, vreg_dest, op);
+	if (dist_dest == -1)
+		ud->int_regs.phys_to_virt[dest->num] = INT_MAX;
+	ud->int_regs.next[dest->num] = dist_dest;
+}
+
+/*
+ * TWO ISSUES TO FIX
+ *
+ * 1. Spill doesn't seem to work properly
+ * 2. Will inserting new registers mess up our distance count, probably?
+ */
+
+static void prv_alloc_mov_instr(void *user_data, subtilis_arm_op_t *op,
+				subtilis_arm_instr_type_t type,
+				subtilis_arm_data_instr_t *instr,
+				subtilis_error_t *err)
+{
+	int dist_op2;
+	subtilis_arm_reg_t *reg;
+	subtilis_arm_reg_ud_t *ud = user_data;
+
+	reg = prv_ensure_op2(ud, op, &instr->op2, &dist_op2, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	prv_allocate_dest(ud, op, &instr->dest, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	if (reg)
+		ud->int_regs.next[reg->num] = dist_op2;
+
+	ud->instr_count++;
+}
+
+static void prv_alloc_data_instr(void *user_data, subtilis_arm_op_t *op,
+				 subtilis_arm_instr_type_t type,
+				 subtilis_arm_data_instr_t *instr,
+				 subtilis_error_t *err)
+{
+	int dist_op1;
+	int dist_op2;
+	size_t vreg_op1;
+	subtilis_arm_reg_ud_t *ud = user_data;
+	subtilis_arm_reg_t *reg = NULL;
+
+	vreg_op1 = instr->op1.num;
+	prv_ensure(ud->arm_p, op, &ud->int_regs, &instr->op1, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	reg = prv_ensure_op2(ud, op, &instr->op2, &dist_op2, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	dist_op1 = prv_calculate_dist(ud, vreg_op1, op);
+	if (dist_op1 == -1)
+		ud->int_regs.phys_to_virt[instr->op1.num] = INT_MAX;
+
+	prv_allocate_dest(ud, op, &instr->dest, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	ud->int_regs.next[instr->op1.num] = dist_op1;
+	if (reg)
+		ud->int_regs.next[reg->num] = dist_op2;
+
+	ud->instr_count++;
+}
+
+static void prv_alloc_stran_instr(void *user_data, subtilis_arm_op_t *op,
+				  subtilis_arm_instr_type_t type,
+				  subtilis_arm_stran_instr_t *instr,
+				  subtilis_error_t *err)
+{
+	int dist_dest;
+	int dist_base;
+	int dist_op2;
+	size_t vreg_dest;
+	size_t vreg_base;
+	subtilis_arm_reg_t *reg = NULL;
+	subtilis_arm_reg_ud_t *ud = user_data;
+
+	if (type == SUBTILIS_ARM_INSTR_STR) {
+		vreg_dest = instr->dest.num;
+		prv_ensure(ud->arm_p, op, &ud->int_regs, &instr->dest, err);
+		if (err->type != SUBTILIS_ERROR_OK)
+			return;
+	}
+
+	vreg_base = instr->base.num;
+	prv_ensure(ud->arm_p, op, &ud->int_regs, &instr->base, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	reg = prv_ensure_op2(ud, op, &instr->offset, &dist_op2, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	dist_base = prv_calculate_dist(ud, vreg_base, op);
+	if (dist_base == -1)
+		ud->int_regs.phys_to_virt[instr->base.num] = INT_MAX;
+
+	if (type == SUBTILIS_ARM_INSTR_STR) {
+		dist_dest = prv_calculate_dist(ud, vreg_dest, op);
+		if (dist_dest == -1)
+			ud->int_regs.phys_to_virt[instr->dest.num] = INT_MAX;
+		ud->int_regs.next[instr->dest.num] = dist_dest;
+	} else {
+		prv_allocate_dest(ud, op, &instr->dest, err);
+		if (err->type != SUBTILIS_ERROR_OK)
+			return;
+	}
+
+	ud->int_regs.next[instr->base.num] = dist_base;
+	if (reg)
+		ud->int_regs.next[reg->num] = dist_op2;
+
+	ud->instr_count++;
+}
+
+static void prv_alloc_mtran_instr(void *user_data, subtilis_arm_op_t *op,
+				  subtilis_arm_instr_type_t type,
+				  subtilis_arm_mtran_instr_t *instr,
+				  subtilis_error_t *err)
+{
+	subtilis_error_set_asssertion_failed(err);
+}
+
+static void prv_alloc_br_instr(void *user_data, subtilis_arm_op_t *op,
+			       subtilis_arm_instr_type_t type,
+			       subtilis_arm_br_instr_t *instr,
+			       subtilis_error_t *err)
+{
+	subtilis_arm_reg_ud_t *ud = user_data;
+
+	ud->instr_count++;
+}
+
+static void prv_alloc_swi_instr(void *user_data, subtilis_arm_op_t *op,
+				subtilis_arm_instr_type_t type,
+				subtilis_arm_swi_instr_t *instr,
+				subtilis_error_t *err)
+{
+	size_t i;
+	subtilis_arm_reg_t reg;
+	subtilis_arm_reg_ud_t *ud = user_data;
+
+	/* SWIs can only use the first 10 regs */
+
+	reg.type = SUBTILIS_ARM_REG_FIXED;
+	for (i = 0; i < 10; i++) {
+		if ((1 << i) & instr->reg_mask) {
+			reg.num = i;
+			prv_allocate_dest(ud, op, &reg, err);
+			if (err->type != SUBTILIS_ERROR_OK)
+				return;
+		}
+	}
+
+	ud->instr_count++;
+}
+
+static void prv_alloc_ldrc_instr(void *user_data, subtilis_arm_op_t *op,
+				 subtilis_arm_instr_type_t type,
+				 subtilis_arm_ldrc_instr_t *instr,
+				 subtilis_error_t *err)
+{
+	subtilis_arm_reg_ud_t *ud = user_data;
+
+	prv_allocate_dest(ud, op, &instr->dest, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	ud->instr_count++;
+}
+
+static void prv_alloc_cmp_instr(void *user_data, subtilis_arm_op_t *op,
+				subtilis_arm_instr_type_t type,
+				subtilis_arm_data_instr_t *instr,
+				subtilis_error_t *err)
+{
+	int dist_op1;
+	int dist_op2;
+	size_t vreg_op1;
+	subtilis_arm_reg_ud_t *ud = user_data;
+	subtilis_arm_reg_t *reg = NULL;
+
+	vreg_op1 = instr->op1.num;
+	prv_ensure(ud->arm_p, op, &ud->int_regs, &instr->op1, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	reg = prv_ensure_op2(ud, op, &instr->op2, &dist_op2, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	dist_op1 = prv_calculate_dist(ud, vreg_op1, op);
+	if (dist_op1 == -1)
+		ud->int_regs.phys_to_virt[instr->op1.num] = INT_MAX;
+
+	ud->int_regs.next[instr->op1.num] = dist_op1;
+	if (reg)
+		ud->int_regs.next[reg->num] = dist_op2;
+
+	ud->instr_count++;
+}
+
+size_t subtilis_arm_reg_alloc(subtilis_arm_program_t *arm_p,
+			      subtilis_error_t *err)
+{
+	subtlis_arm_walker_t walker;
+	subtilis_arm_reg_ud_t ud;
+	size_t retval;
+
+	prv_init_arm_reg_ud(&ud, arm_p, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return 0;
+
+	walker.user_data = &ud;
+	walker.label_fn = prv_alloc_label;
+	walker.data_fn = prv_alloc_data_instr;
+	walker.cmp_fn = prv_alloc_cmp_instr;
+	walker.mov_fn = prv_alloc_mov_instr;
+	walker.stran_fn = prv_alloc_stran_instr;
+	walker.mtran_fn = prv_alloc_mtran_instr;
+	walker.br_fn = prv_alloc_br_instr;
+	walker.swi_fn = prv_alloc_swi_instr;
+	walker.ldrc_fn = prv_alloc_ldrc_instr;
+
+	subtilis_arm_walk(arm_p, &walker, err);
+
+	if (err->type != SUBTILIS_ERROR_OK)
+		goto cleanup;
+
+	retval = ud.int_regs.spill_max;
+
+	prv_free_arm_reg_ud(&ud);
+
+	return retval;
+
+cleanup:
+
+	prv_free_arm_reg_ud(&ud);
+
+	return 0;
+}

--- a/arm_reg_alloc.h
+++ b/arm_reg_alloc.h
@@ -14,24 +14,12 @@
  * limitations under the License.
  */
 
-#ifndef __SUBTILIS_RISCOS_ARM_H
-#define __SUBTILIS_RISCOS_ARM_H
+#ifndef __SUBTILIS_ARM_REG_ALLOC_H
+#define __SUBTILIS_ARM_REG_ALLOC_H
 
 #include "arm_core.h"
 
-/* clang-format off */
-subtilis_arm_program_t *
-subtilis_riscos_generate(
-	subtilis_arm_op_pool_t *pool, subtilis_ir_program_t *p,
-	const subtilis_ir_rule_raw_t *rules_raw,
-	size_t rule_count, size_t globals, subtilis_error_t *err);
-/* clang-format on */
-
-#define SUBTILIS_RISCOS_PRINT_BUFFER 0
-#define SUBTILIS_RISCOS_PRINT_BUFFER_SIZE 32
-#define SUBTILIS_RISCOS_RUNTIME_SIZE SUBTILIS_RISCOS_PRINT_BUFFER_SIZE
-
-void subtilis_riscos_arm_printi(subtilis_ir_program_t *p, size_t start,
-				void *user_data, subtilis_error_t *err);
+size_t subtilis_arm_reg_alloc(subtilis_arm_program_t *arm_p,
+			      subtilis_error_t *err);
 
 #endif

--- a/arm_walker.c
+++ b/arm_walker.c
@@ -18,9 +18,11 @@
 
 #include "arm_walker.h"
 
-static void prv_walk_instr(subtlis_arm_walker_t *walker,
-			   subtilis_arm_instr_t *instr, subtilis_error_t *err)
+static void prv_walk_instr(subtlis_arm_walker_t *walker, subtilis_arm_op_t *op,
+			   subtilis_error_t *err)
 {
+	subtilis_arm_instr_t *instr = &op->op.instr;
+
 	switch (instr->type) {
 	case SUBTILIS_ARM_INSTR_AND:
 	case SUBTILIS_ARM_INSTR_EOR:
@@ -36,59 +38,60 @@ static void prv_walk_instr(subtlis_arm_walker_t *walker,
 	case SUBTILIS_ARM_INSTR_BIC:
 	case SUBTILIS_ARM_INSTR_MUL:
 	case SUBTILIS_ARM_INSTR_MLA:
-		walker->data_fn(walker->user_data, instr->type,
+		walker->data_fn(walker->user_data, op, instr->type,
 				&instr->operands.data, err);
 		break;
 	case SUBTILIS_ARM_INSTR_CMP:
 	case SUBTILIS_ARM_INSTR_CMN:
-		walker->cmp_fn(walker->user_data, instr->type,
+		walker->cmp_fn(walker->user_data, op, instr->type,
 			       &instr->operands.data, err);
 		break;
 	case SUBTILIS_ARM_INSTR_MOV:
 	case SUBTILIS_ARM_INSTR_MVN:
-		walker->mov_fn(walker->user_data, instr->type,
+		walker->mov_fn(walker->user_data, op, instr->type,
 			       &instr->operands.data, err);
 		break;
 	case SUBTILIS_ARM_INSTR_LDR:
 	case SUBTILIS_ARM_INSTR_STR:
-		walker->stran_fn(walker->user_data, instr->type,
+		walker->stran_fn(walker->user_data, op, instr->type,
 				 &instr->operands.stran, err);
 		break;
 	case SUBTILIS_ARM_INSTR_LDM:
 	case SUBTILIS_ARM_INSTR_STM:
-		walker->mtran_fn(walker->user_data, instr->type,
+		walker->mtran_fn(walker->user_data, op, instr->type,
 				 &instr->operands.mtran, err);
 		break;
 	case SUBTILIS_ARM_INSTR_B:
 	case SUBTILIS_ARM_INSTR_BL:
-		walker->br_fn(walker->user_data, instr->type,
+		walker->br_fn(walker->user_data, op, instr->type,
 			      &instr->operands.br, err);
 		break;
 	case SUBTILIS_ARM_INSTR_SWI:
-		walker->swi_fn(walker->user_data, instr->type,
+		walker->swi_fn(walker->user_data, op, instr->type,
 			       &instr->operands.swi, err);
 		break;
 	case SUBTILIS_ARM_INSTR_LDRC:
-		walker->ldrc_fn(walker->user_data, instr->type,
+		walker->ldrc_fn(walker->user_data, op, instr->type,
 				&instr->operands.ldrc, err);
 		break;
 	}
 }
 
-void subtilis_arm_walk(subtilis_arm_program_t *arm_p,
-		       subtlis_arm_walker_t *walker, subtilis_error_t *err)
+static void prv_arm_walk(subtilis_arm_program_t *arm_p, size_t ptr,
+			 subtlis_arm_walker_t *walker, subtilis_error_t *err)
 {
 	subtilis_arm_op_t *op;
-	size_t i;
 
-	for (i = 0; i < arm_p->len; i++) {
-		op = &arm_p->ops[i];
+	while (ptr != SIZE_MAX) {
+		op = &arm_p->pool->ops[ptr];
+
 		switch (op->type) {
 		case SUBTILIS_OP_LABEL:
-			walker->label_fn(walker, op->op.label, err);
+			walker->label_fn(walker->user_data, op, op->op.label,
+					 err);
 			break;
 		case SUBTILIS_OP_INSTR:
-			prv_walk_instr(walker, &op->op.instr, err);
+			prv_walk_instr(walker, op, err);
 			break;
 		default:
 			subtilis_error_set_asssertion_failed(err);
@@ -96,5 +99,25 @@ void subtilis_arm_walk(subtilis_arm_program_t *arm_p,
 		}
 		if (err->type != SUBTILIS_ERROR_OK)
 			return;
+		ptr = op->next;
 	}
+}
+
+void subtilis_arm_walk(subtilis_arm_program_t *arm_p,
+		       subtlis_arm_walker_t *walker, subtilis_error_t *err)
+{
+	return prv_arm_walk(arm_p, arm_p->first_op, walker, err);
+}
+
+void subtilis_arm_walk_from(subtilis_arm_program_t *arm_p,
+			    subtlis_arm_walker_t *walker, subtilis_arm_op_t *op,
+			    subtilis_error_t *err)
+{
+	size_t ptr;
+
+	if (op->next == SIZE_MAX)
+		ptr = arm_p->last_op;
+	else
+		ptr = arm_p->pool->ops[op->next].prev;
+	return prv_arm_walk(arm_p, ptr, walker, err);
 }

--- a/arm_walker.c
+++ b/arm_walker.c
@@ -82,7 +82,7 @@ void subtilis_arm_walk(subtilis_arm_program_t *arm_p,
 	size_t i;
 
 	for (i = 0; i < arm_p->len; i++) {
-		op = &arm_p->ops[arm_p->op_order[i]];
+		op = &arm_p->ops[i];
 		switch (op->type) {
 		case SUBTILIS_OP_LABEL:
 			walker->label_fn(walker, op->op.label, err);

--- a/arm_walker.h
+++ b/arm_walker.h
@@ -26,30 +26,41 @@ typedef struct subtlis_arm_walker_t_ subtlis_arm_walker_t;
 
 struct subtlis_arm_walker_t_ {
 	void *user_data;
-	void (*label_fn)(void *user_data, size_t label, subtilis_error_t *err);
-	void (*data_fn)(void *user_data, subtilis_arm_instr_type_t type,
+	void (*label_fn)(void *user_data, subtilis_arm_op_t *op, size_t label,
+			 subtilis_error_t *err);
+	void (*data_fn)(void *user_data, subtilis_arm_op_t *op,
+			subtilis_arm_instr_type_t type,
 			subtilis_arm_data_instr_t *instr,
 			subtilis_error_t *err);
-	void (*cmp_fn)(void *user_data, subtilis_arm_instr_type_t type,
+	void (*cmp_fn)(void *user_data, subtilis_arm_op_t *op,
+		       subtilis_arm_instr_type_t type,
 		       subtilis_arm_data_instr_t *instr, subtilis_error_t *err);
-	void (*mov_fn)(void *user_data, subtilis_arm_instr_type_t type,
+	void (*mov_fn)(void *user_data, subtilis_arm_op_t *op,
+		       subtilis_arm_instr_type_t type,
 		       subtilis_arm_data_instr_t *instr, subtilis_error_t *err);
-	void (*stran_fn)(void *user_data, subtilis_arm_instr_type_t type,
+	void (*stran_fn)(void *user_data, subtilis_arm_op_t *op,
+			 subtilis_arm_instr_type_t type,
 			 subtilis_arm_stran_instr_t *instr,
 			 subtilis_error_t *err);
-	void (*mtran_fn)(void *user_data, subtilis_arm_instr_type_t type,
+	void (*mtran_fn)(void *user_data, subtilis_arm_op_t *op,
+			 subtilis_arm_instr_type_t type,
 			 subtilis_arm_mtran_instr_t *instr,
 			 subtilis_error_t *err);
-	void (*br_fn)(void *user_data, subtilis_arm_instr_type_t type,
+	void (*br_fn)(void *user_data, subtilis_arm_op_t *op,
+		      subtilis_arm_instr_type_t type,
 		      subtilis_arm_br_instr_t *instr, subtilis_error_t *err);
-	void (*swi_fn)(void *user_data, subtilis_arm_instr_type_t type,
+	void (*swi_fn)(void *user_data, subtilis_arm_op_t *op,
+		       subtilis_arm_instr_type_t type,
 		       subtilis_arm_swi_instr_t *instr, subtilis_error_t *err);
-	void (*ldrc_fn)(void *user_data, subtilis_arm_instr_type_t type,
+	void (*ldrc_fn)(void *user_data, subtilis_arm_op_t *op,
+			subtilis_arm_instr_type_t type,
 			subtilis_arm_ldrc_instr_t *instr,
 			subtilis_error_t *err);
 };
 
 void subtilis_arm_walk(subtilis_arm_program_t *arm_p,
 		       subtlis_arm_walker_t *walker, subtilis_error_t *err);
-
+void subtilis_arm_walk_from(subtilis_arm_program_t *arm_p,
+			    subtlis_arm_walker_t *walker, subtilis_arm_op_t *op,
+			    subtilis_error_t *err);
 #endif

--- a/compiler.c
+++ b/compiler.c
@@ -30,6 +30,7 @@ int main(int argc, char *argv[])
 	subtilis_lexer_t *l = NULL;
 	subtilis_parser_t *p = NULL;
 	subtilis_arm_program_t *arm_p = NULL;
+	subtilis_arm_op_pool_t *pool = NULL;
 
 	if (argc != 2) {
 		fprintf(stderr, "Usage: basicc file\n");
@@ -57,7 +58,11 @@ int main(int argc, char *argv[])
 
 	subtilis_ir_program_dump(p->p);
 
-	arm_p = subtilis_riscos_generate(p->p, riscos_arm2_rules,
+	pool = subtilis_arm_op_pool_new(&err);
+	if (err.type != SUBTILIS_ERROR_OK)
+		goto cleanup;
+
+	arm_p = subtilis_riscos_generate(pool, p->p, riscos_arm2_rules,
 					 riscos_arm2_rules_count,
 					 p->st->allocated, &err);
 	if (err.type != SUBTILIS_ERROR_OK)
@@ -67,6 +72,7 @@ int main(int argc, char *argv[])
 	subtilis_arm_program_dump(arm_p);
 
 	subtilis_arm_program_delete(arm_p);
+	subtilis_arm_op_pool_delete(pool);
 	subtilis_parser_delete(p);
 	subtilis_lexer_delete(l, &err);
 
@@ -74,6 +80,7 @@ int main(int argc, char *argv[])
 
 cleanup:
 	subtilis_arm_program_delete(arm_p);
+	subtilis_arm_op_pool_delete(pool);
 	subtilis_parser_delete(p);
 	if (l)
 		subtilis_lexer_delete(l, &err);

--- a/error.c
+++ b/error.c
@@ -106,6 +106,9 @@ static subtilis_error_desc_t prv_errors[] = {
 
 	/* SUBTILIS_COMPOUND_NOT_TERM */
 	{"Compund statement not terminated.\n", 0},
+
+	/* SUBTILIS_ERROR_WALKER_FAILED */
+	{"Walker failed.\n", 0},
 };
 
 /* clang-format on */

--- a/error.h
+++ b/error.h
@@ -49,6 +49,7 @@ typedef enum {
 	SUBTILIS_ERROR_INTEGER_EXP_EXPECTED,
 	SUBTILIS_ERROR_EXPECTED,
 	SUBTILIS_ERROR_COMPOUND_NOT_TERM,
+	SUBTILIS_ERROR_WALKER_FAILED,
 } subtilis_error_type_t;
 
 struct _subtilis_error_t {
@@ -132,7 +133,9 @@ void subtilis_error_init(subtilis_error_t *e);
 #define subtilis_error_set_compund_not_term(e, file, line)                     \
 	subtilis_error_set_basic(e, SUBTILIS_ERROR_COMPOUND_NOT_TERM, file,    \
 				 line)
-
+#define subtilis_error_set_walker_failed(e)                                    \
+	subtilis_error_set_basic(e, SUBTILIS_ERROR_WALKER_FAILED, __FILE__,    \
+				 __LINE__)
 void subtilis_error_set_full(subtilis_error_t *e, subtilis_error_type_t type,
 			     const char *data1, const char *data2,
 			     const char *file, unsigned int line,


### PR DESCRIPTION
This PR adds a local register allocator for integer registers.
The spill code isn't very well tested yet as it's hard to generate
spill conditions without support for local variables.  Spilling
seems to work okay but I'm not sure that loading non spilled
registers does and I think that spilling might upset distance
calculations.  Need to check this.

Signed-off-by: Mark Ryan <markusdryan@gmail.com>