### PR TITLE
ARM instruction encoder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 DEPS = stream.h lexer.h config.h error.h utils.h keywords.h buffer.h expression.h ir.h hash_table.h symbol_table.h vm.h arm_core.h riscos_arm.h riscos_arm2.h arm_gen.h arm_walker.h
-OBJ = stream.o lexer.o error.o utils.o keywords.o buffer.o parser.o expression.o ir.o hash_table.o symbol_table.o arm_core.o riscos_arm.o riscos_arm2.o arm_gen.o arm_walker.o arm_reg_alloc.o
+OBJ = stream.o lexer.o error.o utils.o keywords.o buffer.o parser.o expression.o ir.o hash_table.o symbol_table.o arm_core.o riscos_arm.o riscos_arm2.o arm_gen.o arm_walker.o arm_reg_alloc.o arm_encode.o
 UNIT_OBJS = unit_tests.o lexer_test.o parser_test.o symbol_table_test.o vm.o ir_test.o arm_core_test.o
 
 CFLAGS ?= -O3

--- a/ROMakefile
+++ b/ROMakefile
@@ -2,7 +2,7 @@
 
 COMPONENT = basicc
 
-OBJS = stream lexer error compiler utils keywords buffer parser expression ir hash_table symbol_table arm_core riscos_arm riscos_arm2 arm_gen arm_walker
+OBJS = stream lexer error compiler utils keywords buffer parser expression ir hash_table symbol_table arm_core riscos_arm riscos_arm2 arm_gen arm_walker arm_reg_alloc arm_encode
 
 CFLAGS ?= -Wxla
 
@@ -30,18 +30,21 @@ o.error:	c.error
 o.error:	h.error
 o.error:	h.config
 o.compiler:	c.compiler
-o.compiler:	h.error
-o.compiler:	h.config
-o.compiler:	h.lexer
+o.compiler:	h.arm_encode
+o.compiler:	h.arm_core
+o.compiler:	h.ir
 o.compiler:	h.buffer
 o.compiler:	h.error
+o.compiler:	h.config
+o.compiler:	h.error
+o.compiler:	h.error
+o.compiler:	h.lexer
+o.compiler:	h.buffer
 o.compiler:	h.keywords
 o.compiler:	h.stream
 o.compiler:	h.error
 o.compiler:	h.parser
 o.compiler:	h.ir
-o.compiler:	h.buffer
-o.compiler:	h.error
 o.compiler:	h.lexer
 o.compiler:	h.symbol_table
 o.compiler:	h.hash_table
@@ -49,7 +52,6 @@ o.compiler:	h.error
 o.compiler:	h.lexer
 o.compiler:	h.riscos_arm
 o.compiler:	h.arm_core
-o.compiler:	h.ir
 o.compiler:	h.riscos_arm2
 o.compiler:	h.ir
 o.utils:	c.utils
@@ -133,22 +135,69 @@ o.arm_core:	h.buffer
 o.arm_core:	h.error
 o.arm_core:	h.config
 o.arm_core:	h.error
+o.arm_core:	h.arm_walker
+o.arm_core:	h.arm_core
+o.arm_core:	h.error
+o.riscos_arm2:	c.riscos_arm2
+o.riscos_arm2:	h.riscos_arm2
+o.riscos_arm2:	h.ir
+o.riscos_arm2:	h.buffer
+o.riscos_arm2:	h.error
+o.riscos_arm2:	h.config
+o.riscos_arm2:	h.error
+o.riscos_arm2:	h.arm_core
+o.riscos_arm2:	h.ir
+o.riscos_arm2:	h.arm_gen
+o.riscos_arm2:	h.ir
+o.riscos_arm2:	h.riscos_arm
+o.riscos_arm2:	h.arm_core
+o.arm_gen:	c.arm_gen
+o.arm_gen:	h.arm_gen
+o.arm_gen:	h.ir
+o.arm_gen:	h.buffer
+o.arm_gen:	h.error
+o.arm_gen:	h.config
+o.arm_gen:	h.error
+o.arm_gen:	h.arm_core
+o.arm_gen:	h.ir
+o.arm_walker:	c.arm_walker
+o.arm_walker:	h.arm_walker
+o.arm_walker:	h.arm_core
+o.arm_walker:	h.ir
+o.arm_walker:	h.buffer
+o.arm_walker:	h.error
+o.arm_walker:	h.config
+o.arm_walker:	h.error
+o.arm_walker:	h.error
 o.riscos_arm:	c.riscos_arm
-o.riscos_arm:	h.riscos_arm
+o.riscos_arm:	h.arm_reg_alloc
 o.riscos_arm:	h.arm_core
 o.riscos_arm:	h.ir
 o.riscos_arm:	h.buffer
 o.riscos_arm:	h.error
 o.riscos_arm:	h.config
 o.riscos_arm:	h.error
-o.riscos_arm2:	c.riscos_arm2
-o.riscos_arm2:	h.riscos_arm
-o.riscos_arm2:	h.arm_core
-o.riscos_arm2:	h.ir
-o.riscos_arm2:	h.buffer
-o.riscos_arm2:	h.error
-o.riscos_arm2:	h.config
-o.riscos_arm2:	h.error
-o.riscos_arm2:	h.riscos_arm2
-o.riscos_arm2:	h.ir
-o.riscos_arm2:	h.arm_core
+o.riscos_arm:	h.riscos_arm
+o.riscos_arm:	h.arm_core
+o.arm_encode:	c.arm_encode
+o.arm_encode:	h.arm_encode
+o.arm_encode:	h.arm_core
+o.arm_encode:	h.ir
+o.arm_encode:	h.buffer
+o.arm_encode:	h.error
+o.arm_encode:	h.config
+o.arm_encode:	h.error
+o.arm_encode:	h.arm_walker
+o.arm_encode:	h.arm_core
+o.arm_encode:	h.error
+o.arm_reg_alloc:	c.arm_reg_alloc
+o.arm_reg_alloc:	h.arm_reg_alloc
+o.arm_reg_alloc:	h.arm_core
+o.arm_reg_alloc:	h.ir
+o.arm_reg_alloc:	h.buffer
+o.arm_reg_alloc:	h.error
+o.arm_reg_alloc:	h.config
+o.arm_reg_alloc:	h.error
+o.arm_reg_alloc:	h.arm_walker
+o.arm_reg_alloc:	h.arm_core
+o.arm_reg_alloc:	h.error

--- a/arm_core.c
+++ b/arm_core.c
@@ -874,6 +874,27 @@ void subtilis_arm_cmp_imm(subtilis_arm_program_t *p,
 	datai->op1 = op1;
 	datai->op2.type = SUBTILIS_ARM_OP2_I32;
 	datai->op2.op.integer = encoded;
+	datai->status = true;
+}
+
+void subtilis_arm_cmp(subtilis_arm_program_t *p,
+		      subtilis_arm_instr_type_t itype,
+		      subtilis_arm_ccode_type_t ccode, subtilis_arm_reg_t op1,
+		      subtilis_arm_reg_t op2, subtilis_error_t *err)
+{
+	subtilis_arm_instr_t *instr;
+	subtilis_arm_data_instr_t *datai;
+
+	instr = subtilis_arm_program_add_instr(p, itype, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	datai = &instr->operands.data;
+	datai->ccode = ccode;
+	datai->op1 = op1;
+	datai->op2.type = SUBTILIS_ARM_OP2_REG;
+	datai->op2.op.reg = op2;
+	datai->status = true;
 }
 
 /* clang-format off */

--- a/arm_core.h
+++ b/arm_core.h
@@ -329,6 +329,10 @@ void subtilis_arm_cmp_imm(subtilis_arm_program_t *p,
 			  subtilis_arm_ccode_type_t ccode,
 			  subtilis_arm_reg_t op1, int32_t op2,
 			  subtilis_error_t *err);
+void subtilis_arm_cmp(subtilis_arm_program_t *p,
+		      subtilis_arm_instr_type_t itype,
+		      subtilis_arm_ccode_type_t ccode, subtilis_arm_reg_t op1,
+		      subtilis_arm_reg_t op2, subtilis_error_t *err);
 
 #define subtilis_arm_add_add_imm(p, cc, s, dst, op1, op2, err)                 \
 	subtilis_arm_add_addsub_imm(p, SUBTILIS_ARM_INSTR_ADD,                 \

--- a/arm_encode.c
+++ b/arm_encode.c
@@ -1,0 +1,414 @@
+/*
+ * Copyright (c) 2017 Mark Ryan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "arm_encode.h"
+#include "arm_walker.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define SUBTILIS_ENCODER_BACKPATCH_GRAN 128
+
+typedef enum {
+	SUBTILIS_ARM_ENCODE_BP_BR,
+	SUBTILIS_ARM_ENCODE_BP_LDR,
+} subtilis_arm_encode_bp_type_t;
+
+struct subtilis_arm_encode_bp_t_ {
+	size_t label;
+	size_t code_index;
+	subtilis_arm_encode_bp_type_t type;
+};
+
+typedef struct subtilis_arm_encode_bp_t_ subtilis_arm_encode_bp_t;
+
+struct subtilis_arm_encode_ud_t_ {
+	size_t *label_offsets;
+	uint32_t *code;
+	size_t words_written;
+	subtilis_arm_encode_bp_t *back_patches;
+	size_t back_patch_count;
+	size_t max_patch_count;
+};
+
+typedef struct subtilis_arm_encode_ud_t_ subtilis_arm_encode_ud_t;
+
+static void prv_init_encode_ud(subtilis_arm_encode_ud_t *ud,
+			       subtilis_arm_program_t *arm_p,
+			       subtilis_error_t *err)
+{
+	memset(ud, 0, sizeof(*ud));
+
+	ud->label_offsets = malloc(sizeof(size_t) * arm_p->label_counter);
+	if (!ud->label_offsets) {
+		subtilis_error_set_oom(err);
+		return;
+	}
+
+	ud->code = malloc(sizeof(uint32_t) *
+			  (arm_p->pool->len + arm_p->constant_count));
+	if (!ud->code) {
+		free(ud->label_offsets);
+		subtilis_error_set_oom(err);
+		return;
+	}
+}
+
+static void prv_free_encode_ud(subtilis_arm_encode_ud_t *ud)
+{
+	free(ud->back_patches);
+	free(ud->code);
+	free(ud->label_offsets);
+}
+
+static void prv_add_back_patch(subtilis_arm_encode_ud_t *ud, size_t label,
+			       size_t code_index,
+			       subtilis_arm_encode_bp_type_t type,
+			       subtilis_error_t *err)
+{
+	size_t new_max;
+	subtilis_arm_encode_bp_t *new_bp;
+
+	if (ud->back_patch_count == ud->max_patch_count) {
+		new_max = ud->max_patch_count + SUBTILIS_ENCODER_BACKPATCH_GRAN;
+		new_bp = realloc(ud->back_patches,
+				 new_max * sizeof(subtilis_arm_encode_bp_t));
+		if (!new_bp) {
+			subtilis_error_set_oom(err);
+			return;
+		}
+		ud->max_patch_count = new_max;
+		ud->back_patches = new_bp;
+	}
+	new_bp = &ud->back_patches[ud->back_patch_count++];
+	new_bp->label = label;
+	new_bp->code_index = code_index;
+	new_bp->type = type;
+}
+
+static void prv_write_file(subtilis_arm_encode_ud_t *ud, const char *fname,
+			   subtilis_error_t *err)
+{
+	FILE *fp;
+
+	fp = fopen(fname, "w");
+	if (!fp) {
+		subtilis_error_set_file_open(err, fname);
+		return;
+	}
+
+	if (fwrite(ud->code, sizeof(uint32_t), ud->words_written, fp) <
+	    ud->words_written) {
+		subtilis_error_set_file_write(err);
+		goto fail;
+	}
+
+	if (fclose(fp) != 0)
+		subtilis_error_set_file_close(err);
+
+	return;
+
+fail:
+
+	(void)fclose(fp);
+}
+
+static void prv_encode_data_op2(subtilis_arm_op2_t *op2, uint32_t *word,
+				subtilis_error_t *err)
+{
+	if (op2->type == SUBTILIS_ARM_OP2_REG) {
+		if (op2->op.reg.num > 15) {
+			subtilis_error_set_asssertion_failed(err);
+			return;
+		}
+		*word |= op2->op.reg.num;
+	} else if (op2->type == SUBTILIS_ARM_OP2_I32) {
+		if (op2->op.integer & 0xfffff000) {
+			subtilis_error_set_asssertion_failed(err);
+			return;
+		}
+		*word |= op2->op.integer;
+		*word |= 1 << 25;
+	} else if (op2->type == SUBTILIS_ARM_OP2_SHIFTED) {
+		if (op2->op.shift.reg.num > 15) {
+			subtilis_error_set_asssertion_failed(err);
+			return;
+		}
+
+		/* TODO currently i have no idea how to encode the shifts */
+
+		*word |= op2->op.shift.shift << 8;
+
+		subtilis_error_set_asssertion_failed(err);
+	}
+}
+
+static void prv_encode_data_instr(void *user_data, subtilis_arm_op_t *op,
+				  subtilis_arm_instr_type_t type,
+				  subtilis_arm_data_instr_t *instr,
+				  subtilis_error_t *err)
+{
+	subtilis_arm_encode_ud_t *ud = user_data;
+	uint32_t word = 0;
+
+	if (instr->dest.num > 15) {
+		subtilis_error_set_asssertion_failed(err);
+		return;
+	}
+
+	word |= instr->ccode << 28;
+	word |= type << 21;
+	if (instr->status)
+		word |= 1 << 20;
+	word |= instr->op1.num << 16;
+	word |= instr->dest.num << 12;
+	prv_encode_data_op2(&instr->op2, &word, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	ud->code[ud->words_written++] = word;
+}
+
+static void prv_encode_mov_instr(void *user_data, subtilis_arm_op_t *op,
+				 subtilis_arm_instr_type_t type,
+				 subtilis_arm_data_instr_t *instr,
+				 subtilis_error_t *err)
+{
+	prv_encode_data_instr(user_data, op, type, instr, err);
+}
+
+static void prv_encode_stran_op2(subtilis_arm_op2_t *op2, uint32_t *word,
+				 subtilis_error_t *err)
+{
+	if (op2->type == SUBTILIS_ARM_OP2_REG) {
+		if (op2->op.reg.num > 15) {
+			subtilis_error_set_asssertion_failed(err);
+			return;
+		}
+		*word |= 1 << 25;
+		*word |= op2->op.reg.num;
+	} else if (op2->type == SUBTILIS_ARM_OP2_I32) {
+		if (op2->op.integer > 4095) {
+			subtilis_error_set_asssertion_failed(err);
+			return;
+		}
+		*word |= op2->op.integer;
+	} else if (op2->type == SUBTILIS_ARM_OP2_SHIFTED) {
+		if (op2->op.shift.reg.num > 15) {
+			subtilis_error_set_asssertion_failed(err);
+			return;
+		}
+
+		/* TODO currently i have no idea how to encode the shifts */
+
+		*word |= 1 << 25;
+		*word |= op2->op.shift.shift << 8;
+
+		subtilis_error_set_asssertion_failed(err);
+	}
+}
+
+static void prv_encode_stran_instr(void *user_data, subtilis_arm_op_t *op,
+				   subtilis_arm_instr_type_t type,
+				   subtilis_arm_stran_instr_t *instr,
+				   subtilis_error_t *err)
+{
+	subtilis_arm_encode_ud_t *ud = user_data;
+	uint32_t word = 0;
+
+	if ((instr->base.num > 15) || (instr->dest.num > 15)) {
+		subtilis_error_set_asssertion_failed(err);
+		return;
+	}
+
+	word |= instr->ccode << 28;
+	word |= 1 << 26;
+	if (instr->pre_indexed)
+		word |= 1 << 24;
+
+	/* TODO: STRAN does not implement negative offsets correctly */
+	word |= 1 << 23;
+	if (instr->write_back)
+		word |= 1 << 21;
+	if (type == SUBTILIS_ARM_INSTR_LDR)
+		word |= 1 << 20;
+	word |= instr->base.num << 16;
+	word |= instr->dest.num << 12;
+	prv_encode_stran_op2(&instr->offset, &word, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	ud->code[ud->words_written++] = word;
+}
+
+static void prv_encode_mtran_instr(void *user_data, subtilis_arm_op_t *op,
+				   subtilis_arm_instr_type_t type,
+				   subtilis_arm_mtran_instr_t *instr,
+				   subtilis_error_t *err)
+{
+	subtilis_error_set_asssertion_failed(err);
+}
+
+static void prv_encode_br_instr(void *user_data, subtilis_arm_op_t *op,
+				subtilis_arm_instr_type_t type,
+				subtilis_arm_br_instr_t *instr,
+				subtilis_error_t *err)
+{
+	subtilis_arm_encode_ud_t *ud = user_data;
+	uint32_t word = 0;
+
+	word |= instr->ccode << 28;
+	word |= 0x5 << 25;
+	if (instr->link)
+		word |= 1 << 24;
+
+	prv_add_back_patch(ud, instr->label, ud->words_written,
+			   SUBTILIS_ARM_ENCODE_BP_BR, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+	ud->code[ud->words_written++] = word;
+}
+
+static void prv_encode_swi_instr(void *user_data, subtilis_arm_op_t *op,
+				 subtilis_arm_instr_type_t type,
+				 subtilis_arm_swi_instr_t *instr,
+				 subtilis_error_t *err)
+{
+	subtilis_arm_encode_ud_t *ud = user_data;
+	uint32_t word = 0;
+
+	word |= instr->ccode << 28;
+	word |= 0xf << 24;
+	word |= 0x0fffffff & instr->code;
+
+	ud->code[ud->words_written++] = word;
+}
+
+static void prv_encode_ldrc_instr(void *user_data, subtilis_arm_op_t *op,
+				  subtilis_arm_instr_type_t type,
+				  subtilis_arm_ldrc_instr_t *instr,
+				  subtilis_error_t *err)
+{
+	subtilis_arm_stran_instr_t stran;
+	subtilis_arm_encode_ud_t *ud = user_data;
+
+	prv_add_back_patch(ud, instr->label, ud->words_written,
+			   SUBTILIS_ARM_ENCODE_BP_LDR, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	stran.ccode = instr->ccode;
+	stran.dest = instr->dest;
+	stran.base.type = SUBTILIS_ARM_REG_FIXED;
+	stran.base.num = 15;
+	stran.offset.type = SUBTILIS_ARM_OP2_I32;
+	stran.offset.op.integer = 0;
+	stran.pre_indexed = true;
+	stran.write_back = false;
+	prv_encode_stran_instr(user_data, op, SUBTILIS_ARM_INSTR_LDR, &stran,
+			       err);
+}
+
+static void prv_encode_cmp_instr(void *user_data, subtilis_arm_op_t *op,
+				 subtilis_arm_instr_type_t type,
+				 subtilis_arm_data_instr_t *instr,
+				 subtilis_error_t *err)
+{
+	prv_encode_data_instr(user_data, op, type, instr, err);
+}
+
+static void prv_encode_label(void *user_data, subtilis_arm_op_t *op,
+			     size_t label, subtilis_error_t *err)
+{
+	subtilis_arm_encode_ud_t *ud = user_data;
+
+	ud->label_offsets[label] = ud->words_written;
+}
+
+static void prv_apply_back_patches(subtilis_arm_encode_ud_t *ud,
+				   subtilis_error_t *err)
+{
+	subtilis_arm_encode_bp_t *bp;
+	size_t i;
+	int32_t dist;
+
+	for (i = 0; i < ud->back_patch_count; i++) {
+		bp = &ud->back_patches[i];
+		dist = (ud->label_offsets[bp->label] - bp->code_index) - 2;
+		switch (bp->type) {
+		case SUBTILIS_ARM_ENCODE_BP_BR:
+			if ((dist < -(1 << 23)) || (dist > ((1 << 23) - 1))) {
+				subtilis_error_set_asssertion_failed(err);
+				return;
+			}
+			dist &= 0xffffff;
+			break;
+		case SUBTILIS_ARM_ENCODE_BP_LDR:
+			if (dist < 0)
+				dist = -dist;
+			dist *= 4;
+			if (dist > 4096) {
+				subtilis_error_set_asssertion_failed(err);
+				return;
+			}
+			break;
+		}
+		ud->code[bp->code_index] |= dist;
+	}
+}
+
+void subtilis_arm_encode(subtilis_arm_program_t *arm_p, const char *fname,
+			 subtilis_error_t *err)
+{
+	subtlis_arm_walker_t walker;
+	subtilis_arm_encode_ud_t ud;
+	size_t i;
+
+	prv_init_encode_ud(&ud, arm_p, err);
+
+	walker.user_data = &ud;
+	walker.label_fn = prv_encode_label;
+	walker.data_fn = prv_encode_data_instr;
+	walker.cmp_fn = prv_encode_cmp_instr;
+	walker.mov_fn = prv_encode_mov_instr;
+	walker.stran_fn = prv_encode_stran_instr;
+	walker.mtran_fn = prv_encode_mtran_instr;
+	walker.br_fn = prv_encode_br_instr;
+	walker.swi_fn = prv_encode_swi_instr;
+	walker.ldrc_fn = prv_encode_ldrc_instr;
+
+	subtilis_arm_walk(arm_p, &walker, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		goto cleanup;
+
+	for (i = 0; i < arm_p->constant_count; i++) {
+		ud.label_offsets[arm_p->constants[i].label] = ud.words_written;
+		ud.code[ud.words_written++] = arm_p->constants[i].integer;
+		if (err->type != SUBTILIS_ERROR_OK)
+			goto cleanup;
+	}
+
+	prv_apply_back_patches(&ud, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		goto cleanup;
+
+	prv_write_file(&ud, fname, err);
+
+cleanup:
+
+	prv_free_encode_ud(&ud);
+}

--- a/arm_encode.h
+++ b/arm_encode.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2017 Mark Ryan
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __SUBTILIS_ARM_ENCODE_H
+#define __SUBTILIS_ARM_ENCODE_H
+
+#include "arm_core.h"
+
+void subtilis_arm_encode(subtilis_arm_program_t *arm_p, const char *fname,
+			 subtilis_error_t *err);
+
+#endif

--- a/arm_gen.c
+++ b/arm_gen.c
@@ -40,6 +40,22 @@ static void prv_data_simple(subtilis_ir_program_t *p, size_t start,
 	datai->op2.op.reg = subtilis_arm_ir_to_arm_reg(ir_op->operands[2].reg);
 }
 
+static void prv_cmp_simple(subtilis_ir_program_t *p, size_t start,
+			   void *user_data, subtilis_arm_instr_type_t itype,
+			   subtilis_arm_ccode_type_t ccode,
+			   subtilis_error_t *err)
+{
+	subtilis_arm_reg_t op1;
+	subtilis_arm_reg_t op2;
+	subtilis_arm_program_t *arm_p = user_data;
+	subtilis_ir_inst_t *ir_op = &p->ops[start]->op.instr;
+
+	op1 = subtilis_arm_ir_to_arm_reg(ir_op->operands[1].reg);
+	op2 = subtilis_arm_ir_to_arm_reg(ir_op->operands[2].reg);
+
+	subtilis_arm_cmp(arm_p, itype, ccode, op1, op2, err);
+}
+
 void subtilis_arm_gen_movii32(subtilis_ir_program_t *p, size_t start,
 			      void *user_data, subtilis_error_t *err)
 {
@@ -248,8 +264,8 @@ static void prv_cmp_jmp(subtilis_ir_program_t *p, size_t start, void *user_data,
 	subtilis_arm_program_t *arm_p = user_data;
 	subtilis_ir_inst_t *jmp = &p->ops[start + 1]->op.instr;
 
-	prv_data_simple(p, start, user_data, SUBTILIS_ARM_INSTR_CMP,
-			SUBTILIS_ARM_CCODE_AL, err);
+	prv_cmp_simple(p, start, user_data, SUBTILIS_ARM_INSTR_CMP,
+		       SUBTILIS_ARM_CCODE_AL, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
 
@@ -346,8 +362,8 @@ static void prv_cmp(subtilis_ir_program_t *p, size_t start, void *user_data,
 	subtilis_arm_program_t *arm_p = user_data;
 	subtilis_ir_inst_t *cmp = &p->ops[start]->op.instr;
 
-	prv_data_simple(p, start, user_data, SUBTILIS_ARM_INSTR_CMP,
-			SUBTILIS_ARM_CCODE_AL, err);
+	prv_cmp_simple(p, start, user_data, SUBTILIS_ARM_INSTR_CMP,
+		       SUBTILIS_ARM_CCODE_AL, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
 

--- a/arm_walker.c
+++ b/arm_walker.c
@@ -106,7 +106,7 @@ static void prv_arm_walk(subtilis_arm_program_t *arm_p, size_t ptr,
 void subtilis_arm_walk(subtilis_arm_program_t *arm_p,
 		       subtlis_arm_walker_t *walker, subtilis_error_t *err)
 {
-	return prv_arm_walk(arm_p, arm_p->first_op, walker, err);
+	prv_arm_walk(arm_p, arm_p->first_op, walker, err);
 }
 
 void subtilis_arm_walk_from(subtilis_arm_program_t *arm_p,
@@ -119,5 +119,5 @@ void subtilis_arm_walk_from(subtilis_arm_program_t *arm_p,
 		ptr = arm_p->last_op;
 	else
 		ptr = arm_p->pool->ops[op->next].prev;
-	return prv_arm_walk(arm_p, ptr, walker, err);
+	prv_arm_walk(arm_p, ptr, walker, err);
 }

--- a/compiler.c
+++ b/compiler.c
@@ -17,6 +17,7 @@
 #include <locale.h>
 #include <stdio.h>
 
+#include "arm_encode.h"
 #include "error.h"
 #include "lexer.h"
 #include "parser.h"
@@ -70,6 +71,10 @@ int main(int argc, char *argv[])
 
 	printf("\n\n");
 	subtilis_arm_program_dump(arm_p);
+
+	subtilis_arm_encode(arm_p, "RunImage", &err);
+	if (err.type != SUBTILIS_ERROR_OK)
+		goto cleanup;
 
 	subtilis_arm_program_delete(arm_p);
 	subtilis_arm_op_pool_delete(pool);

--- a/error.c
+++ b/error.c
@@ -41,6 +41,9 @@ static subtilis_error_desc_t prv_errors[] = {
 	/* SUBTILIS_ERROR_READ */
 	{"Failed to read from file, err: %s.\n", 1},
 
+	/* SUBTILIS_ERROR_WRITE */
+	{"Failed to write to file, err: %s.\n", 1},
+
 	/* SUBTILIS_ERROR_CLOSE */
 	{"Failed to close file, err: %s.\n", 1},
 

--- a/error.h
+++ b/error.h
@@ -27,6 +27,7 @@ typedef enum {
 	SUBTILIS_ERROR_OOM,
 	SUBTILIS_ERROR_OPEN,
 	SUBTILIS_ERROR_READ,
+	SUBTILIS_ERROR_WRITE,
 	SUBTILIS_ERROR_CLOSE,
 	SUBTILIS_ERROR_UNTERMINATED_STRING,
 	SUBTILIS_ERROR_STRING_TOO_LONG,
@@ -81,6 +82,9 @@ void subtilis_error_init(subtilis_error_t *e);
 				 __LINE__)
 #define subtilis_error_set_file_read(e)                                        \
 	subtilis_error_set_errno(e, SUBTILIS_ERROR_READ, "", __FILE__, __LINE__)
+#define subtilis_error_set_file_write(e)                                       \
+	subtilis_error_set_errno(e, SUBTILIS_ERROR_WRITE, "", __FILE__,        \
+				 __LINE__)
 #define subtilis_error_set_file_close(e)                                       \
 	subtilis_error_set_errno(e, SUBTILIS_ERROR_CLOSE, "", __FILE__,        \
 				 __LINE__)

--- a/riscos_arm.c
+++ b/riscos_arm.c
@@ -19,7 +19,8 @@
 #include "arm_reg_alloc.h"
 #include "riscos_arm.h"
 
-size_t prv_add_preamble(subtilis_arm_program_t *arm_p, subtilis_error_t *err)
+static size_t prv_add_preamble(subtilis_arm_program_t *arm_p,
+			       subtilis_error_t *err)
 {
 	subtilis_arm_instr_t *instr;
 	subtilis_arm_reg_t dest;
@@ -58,7 +59,7 @@ size_t prv_add_preamble(subtilis_arm_program_t *arm_p, subtilis_error_t *err)
 	return label;
 }
 
-void prv_add_coda(subtilis_arm_program_t *arm_p, subtilis_error_t *err)
+static void prv_add_coda(subtilis_arm_program_t *arm_p, subtilis_error_t *err)
 {
 	subtilis_arm_instr_t *instr;
 	subtilis_arm_reg_t dest;


### PR DESCRIPTION
This PR adds an encoder for ARM.  The compiler now generates ARM binaries which are directly executable on a RISCOS machine, providing you set the Type to &FF8.  The PR also fixes a memory corruption issue with the register allocator.