### PR TITLE
Fix encoding issues and general spring cleaning

### DIFF
--- a/arm_core.c
+++ b/arm_core.c
@@ -676,6 +676,23 @@ void subtilis_arm_add_data_imm(subtilis_arm_program_t *p,
 	datai->op2 = data_opt2;
 }
 
+void subtilis_arm_add_swi(subtilis_arm_program_t *p,
+			  subtilis_arm_ccode_type_t ccode, size_t code,
+			  uint32_t reg_mask, subtilis_error_t *err)
+{
+	subtilis_arm_instr_t *instr;
+	subtilis_arm_swi_instr_t *swi;
+
+	instr = subtilis_arm_program_add_instr(p, SUBTILIS_ARM_INSTR_SWI, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	swi = &instr->operands.swi;
+	swi->ccode = ccode;
+	swi->code = code;
+	swi->reg_mask = reg_mask;
+}
+
 void subtilis_arm_movmvn_reg(subtilis_arm_program_t *p,
 			     subtilis_arm_instr_type_t itype,
 			     subtilis_arm_ccode_type_t ccode, bool status,

--- a/arm_core.c
+++ b/arm_core.c
@@ -589,7 +589,7 @@ void subtilis_arm_add_mul_imm(subtilis_arm_program_t *p,
 	subtilis_arm_data_instr_t *datai;
 
 	mov_dest = prv_acquire_new_reg(p);
-	subtilis_arm_mov_imm(p, ccode, false, mov_dest, op2, err);
+	subtilis_arm_add_mov_imm(p, ccode, false, mov_dest, op2, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
 
@@ -654,7 +654,7 @@ void subtilis_arm_add_data_imm(subtilis_arm_program_t *p,
 
 	if (!subtilis_arm_encode_imm(op2, &encoded)) {
 		mov_dest = prv_acquire_new_reg(p);
-		subtilis_arm_mov_imm(p, ccode, false, mov_dest, op2, err);
+		subtilis_arm_add_mov_imm(p, ccode, false, mov_dest, op2, err);
 		if (err->type != SUBTILIS_ERROR_OK)
 			return;
 		data_opt2.type = SUBTILIS_ARM_OP2_REG;
@@ -693,11 +693,11 @@ void subtilis_arm_add_swi(subtilis_arm_program_t *p,
 	swi->reg_mask = reg_mask;
 }
 
-void subtilis_arm_movmvn_reg(subtilis_arm_program_t *p,
-			     subtilis_arm_instr_type_t itype,
-			     subtilis_arm_ccode_type_t ccode, bool status,
-			     subtilis_arm_reg_t dest, subtilis_arm_reg_t op2,
-			     subtilis_error_t *err)
+void subtilis_arm_add_movmvn_reg(subtilis_arm_program_t *p,
+				 subtilis_arm_instr_type_t itype,
+				 subtilis_arm_ccode_type_t ccode, bool status,
+				 subtilis_arm_reg_t dest,
+				 subtilis_arm_reg_t op2, subtilis_error_t *err)
 {
 	subtilis_arm_instr_t *instr;
 	subtilis_arm_data_instr_t *datai;
@@ -714,12 +714,12 @@ void subtilis_arm_movmvn_reg(subtilis_arm_program_t *p,
 	datai->op2.op.reg = op2;
 }
 
-void subtilis_arm_movmvn_imm(subtilis_arm_program_t *p,
-			     subtilis_arm_instr_type_t itype,
-			     subtilis_arm_instr_type_t alt_type,
-			     subtilis_arm_ccode_type_t ccode, bool status,
-			     subtilis_arm_reg_t dest, int32_t op2,
-			     subtilis_error_t *err)
+void subtilis_arm_add_movmvn_imm(subtilis_arm_program_t *p,
+				 subtilis_arm_instr_type_t itype,
+				 subtilis_arm_instr_type_t alt_type,
+				 subtilis_arm_ccode_type_t ccode, bool status,
+				 subtilis_arm_reg_t dest, int32_t op2,
+				 subtilis_error_t *err)
 {
 	subtilis_arm_instr_t *instr;
 	subtilis_arm_data_instr_t *datai;
@@ -746,11 +746,12 @@ void subtilis_arm_movmvn_imm(subtilis_arm_program_t *p,
 	datai->op2.op.integer = encoded;
 }
 
-void subtilis_arm_stran_imm(subtilis_arm_program_t *p,
-			    subtilis_arm_instr_type_t itype,
-			    subtilis_arm_ccode_type_t ccode,
-			    subtilis_arm_reg_t dest, subtilis_arm_reg_t base,
-			    int32_t offset, subtilis_error_t *err)
+void subtilis_arm_add_stran_imm(subtilis_arm_program_t *p,
+				subtilis_arm_instr_type_t itype,
+				subtilis_arm_ccode_type_t ccode,
+				subtilis_arm_reg_t dest,
+				subtilis_arm_reg_t base, int32_t offset,
+				subtilis_error_t *err)
 {
 	subtilis_arm_op2_t op2;
 	subtilis_arm_instr_t *instr;
@@ -905,10 +906,10 @@ void subtilis_arm_insert_stran_imm(subtilis_arm_program_t *p,
 	stran->write_back = false;
 }
 
-void subtilis_arm_cmp_imm(subtilis_arm_program_t *p,
-			  subtilis_arm_ccode_type_t ccode,
-			  subtilis_arm_reg_t op1, int32_t op2,
-			  subtilis_error_t *err)
+void subtilis_arm_add_cmp_imm(subtilis_arm_program_t *p,
+			      subtilis_arm_ccode_type_t ccode,
+			      subtilis_arm_reg_t op1, int32_t op2,
+			      subtilis_error_t *err)
 {
 	subtilis_arm_instr_t *instr;
 	subtilis_arm_instr_type_t itype;
@@ -942,10 +943,11 @@ void subtilis_arm_cmp_imm(subtilis_arm_program_t *p,
 	datai->status = true;
 }
 
-void subtilis_arm_cmp(subtilis_arm_program_t *p,
-		      subtilis_arm_instr_type_t itype,
-		      subtilis_arm_ccode_type_t ccode, subtilis_arm_reg_t op1,
-		      subtilis_arm_reg_t op2, subtilis_error_t *err)
+void subtilis_arm_add_cmp(subtilis_arm_program_t *p,
+			  subtilis_arm_instr_type_t itype,
+			  subtilis_arm_ccode_type_t ccode,
+			  subtilis_arm_reg_t op1, subtilis_arm_reg_t op2,
+			  subtilis_error_t *err)
 {
 	subtilis_arm_instr_t *instr;
 	subtilis_arm_data_instr_t *datai;

--- a/arm_core.c
+++ b/arm_core.c
@@ -231,6 +231,7 @@ void subtilis_arm_program_add_label(subtilis_arm_program_t *p, size_t label,
 		return;
 	op->type = SUBTILIS_OP_LABEL;
 	op->op.label = label;
+	p->label_counter++;
 }
 
 static void prv_add_constant(subtilis_arm_program_t *p, size_t label,

--- a/arm_core.h
+++ b/arm_core.h
@@ -294,22 +294,23 @@ void subtilis_arm_add_data_imm(subtilis_arm_program_t *p,
 void subtilis_arm_add_swi(subtilis_arm_program_t *p,
 			  subtilis_arm_ccode_type_t ccode, size_t code,
 			  uint32_t reg_mask, subtilis_error_t *err);
-void subtilis_arm_movmvn_reg(subtilis_arm_program_t *p,
-			     subtilis_arm_instr_type_t itype,
-			     subtilis_arm_ccode_type_t ccode, bool status,
-			     subtilis_arm_reg_t dest, subtilis_arm_reg_t op1,
-			     subtilis_error_t *err);
-void subtilis_arm_movmvn_imm(subtilis_arm_program_t *p,
-			     subtilis_arm_instr_type_t itype,
-			     subtilis_arm_instr_type_t alt_type,
-			     subtilis_arm_ccode_type_t ccode, bool status,
-			     subtilis_arm_reg_t dest, int32_t op2,
-			     subtilis_error_t *err);
-void subtilis_arm_stran_imm(subtilis_arm_program_t *p,
-			    subtilis_arm_instr_type_t itype,
-			    subtilis_arm_ccode_type_t ccode,
-			    subtilis_arm_reg_t dest, subtilis_arm_reg_t base,
-			    int32_t offset, subtilis_error_t *err);
+void subtilis_arm_add_movmvn_reg(subtilis_arm_program_t *p,
+				 subtilis_arm_instr_type_t itype,
+				 subtilis_arm_ccode_type_t ccode, bool status,
+				 subtilis_arm_reg_t dest,
+				 subtilis_arm_reg_t op1, subtilis_error_t *err);
+void subtilis_arm_add_movmvn_imm(subtilis_arm_program_t *p,
+				 subtilis_arm_instr_type_t itype,
+				 subtilis_arm_instr_type_t alt_type,
+				 subtilis_arm_ccode_type_t ccode, bool status,
+				 subtilis_arm_reg_t dest, int32_t op2,
+				 subtilis_error_t *err);
+void subtilis_arm_add_stran_imm(subtilis_arm_program_t *p,
+				subtilis_arm_instr_type_t itype,
+				subtilis_arm_ccode_type_t ccode,
+				subtilis_arm_reg_t dest,
+				subtilis_arm_reg_t base, int32_t offset,
+				subtilis_error_t *err);
 void subtilis_arm_insert_push(subtilis_arm_program_t *arm_p,
 			      subtilis_arm_op_t *current,
 			      subtilis_arm_ccode_type_t ccode, size_t reg_num,
@@ -335,14 +336,15 @@ void subtilis_arm_insert_stran_imm(subtilis_arm_program_t *p,
 				   subtilis_arm_reg_t dest,
 				   subtilis_arm_reg_t base, int32_t offset,
 				   subtilis_error_t *err);
-void subtilis_arm_cmp_imm(subtilis_arm_program_t *p,
+void subtilis_arm_add_cmp_imm(subtilis_arm_program_t *p,
+			      subtilis_arm_ccode_type_t ccode,
+			      subtilis_arm_reg_t op1, int32_t op2,
+			      subtilis_error_t *err);
+void subtilis_arm_add_cmp(subtilis_arm_program_t *p,
+			  subtilis_arm_instr_type_t itype,
 			  subtilis_arm_ccode_type_t ccode,
-			  subtilis_arm_reg_t op1, int32_t op2,
+			  subtilis_arm_reg_t op1, subtilis_arm_reg_t op2,
 			  subtilis_error_t *err);
-void subtilis_arm_cmp(subtilis_arm_program_t *p,
-		      subtilis_arm_instr_type_t itype,
-		      subtilis_arm_ccode_type_t ccode, subtilis_arm_reg_t op1,
-		      subtilis_arm_reg_t op2, subtilis_error_t *err);
 
 #define subtilis_arm_add_add_imm(p, cc, s, dst, op1, op2, err)                 \
 	subtilis_arm_add_addsub_imm(p, SUBTILIS_ARM_INSTR_ADD,                 \
@@ -352,16 +354,20 @@ void subtilis_arm_cmp(subtilis_arm_program_t *p,
 	subtilis_arm_add_addsub_imm(p, SUBTILIS_ARM_INSTR_SUB,                 \
 				    SUBTILIS_ARM_INSTR_ADD, cc, s, dst, op1,   \
 				    op2, err)
-#define subtilis_arm_mov_imm(p, cc, s, dst, op2, err)                          \
-	subtilis_arm_movmvn_imm(p, SUBTILIS_ARM_INSTR_MOV,                     \
-				SUBTILIS_ARM_INSTR_MVN, cc, s, dst, op2, err)
-#define subtilis_arm_mvn_imm(p, cc, s, dst, op2, err)                          \
-	subtilis_arm_movmvn_imm(p, SUBTILIS_ARM_INSTR_MVN,                     \
-				SUBTILIS_ARM_INSTR_MOV, cc, s, dst, op2, err)
-#define subtilis_arm_mov_reg(p, cc, s, dst, op2, err)                          \
-	subtilis_arm_movmvn_reg(p, SUBTILIS_ARM_INSTR_MOV, cc, s, dst, op2, err)
-#define subtilis_arm_mvn_reg(p, cc, s, dst, op2, err)                          \
-	subtilis_arm_movmvn_reg(p, SUBTILIS_ARM_INSTR_MVN, cc, s, dst, op2, err)
+#define subtilis_arm_add_mov_imm(p, cc, s, dst, op2, err)                      \
+	subtilis_arm_add_movmvn_imm(p, SUBTILIS_ARM_INSTR_MOV,                 \
+				    SUBTILIS_ARM_INSTR_MVN, cc, s, dst, op2,   \
+				    err)
+#define subtilis_arm_add_mvn_imm(p, cc, s, dst, op2, err)                      \
+	subtilis_arm_add_movmvn_imm(p, SUBTILIS_ARM_INSTR_MVN,                 \
+				    SUBTILIS_ARM_INSTR_MOV, cc, s, dst, op2,   \
+				    err)
+#define subtilis_arm_add_mov_reg(p, cc, s, dst, op2, err)                      \
+	subtilis_arm_add_movmvn_reg(p, SUBTILIS_ARM_INSTR_MOV, cc, s, dst,     \
+				    op2, err)
+#define subtilis_arm_add_mvn_reg(p, cc, s, dst, op2, err)                      \
+	subtilis_arm_add_movmvn_reg(p, SUBTILIS_ARM_INSTR_MVN, cc, s, dst,     \
+				    op2, err)
 void subtilis_arm_program_dump(subtilis_arm_program_t *p);
 
 #endif

--- a/arm_core.h
+++ b/arm_core.h
@@ -291,6 +291,9 @@ void subtilis_arm_add_data_imm(subtilis_arm_program_t *p,
 			       subtilis_arm_ccode_type_t ccode, bool status,
 			       subtilis_arm_reg_t dest, subtilis_arm_reg_t op1,
 			       int32_t op2, subtilis_error_t *err);
+void subtilis_arm_add_swi(subtilis_arm_program_t *p,
+			  subtilis_arm_ccode_type_t ccode, size_t code,
+			  uint32_t reg_mask, subtilis_error_t *err);
 void subtilis_arm_movmvn_reg(subtilis_arm_program_t *p,
 			     subtilis_arm_instr_type_t itype,
 			     subtilis_arm_ccode_type_t ccode, bool status,

--- a/arm_encode.c
+++ b/arm_encode.c
@@ -38,6 +38,7 @@ typedef struct subtilis_arm_encode_bp_t_ subtilis_arm_encode_bp_t;
 
 struct subtilis_arm_encode_ud_t_ {
 	size_t *label_offsets;
+	size_t max_labels;
 	uint32_t *code;
 	size_t words_written;
 	subtilis_arm_encode_bp_t *back_patches;
@@ -53,7 +54,8 @@ static void prv_init_encode_ud(subtilis_arm_encode_ud_t *ud,
 {
 	memset(ud, 0, sizeof(*ud));
 
-	ud->label_offsets = malloc(sizeof(size_t) * arm_p->label_counter);
+	ud->max_labels = arm_p->label_counter;
+	ud->label_offsets = malloc(sizeof(size_t) * ud->max_labels);
 	if (!ud->label_offsets) {
 		subtilis_error_set_oom(err);
 		return;
@@ -368,6 +370,11 @@ static void prv_encode_label(void *user_data, subtilis_arm_op_t *op,
 			     size_t label, subtilis_error_t *err)
 {
 	subtilis_arm_encode_ud_t *ud = user_data;
+
+	if (label >= ud->max_labels) {
+		subtilis_error_set_asssertion_failed(err);
+		return;
+	}
 
 	ud->label_offsets[label] = ud->words_written;
 }

--- a/arm_encode.h
+++ b/arm_encode.h
@@ -21,5 +21,7 @@
 
 void subtilis_arm_encode(subtilis_arm_program_t *arm_p, const char *fname,
 			 subtilis_error_t *err);
+uint32_t *subtilis_arm_encode_buf(subtilis_arm_program_t *arm_p,
+				  subtilis_error_t *err);
 
 #endif

--- a/arm_gen.c
+++ b/arm_gen.c
@@ -53,7 +53,7 @@ static void prv_cmp_simple(subtilis_ir_program_t *p, size_t start,
 	op1 = subtilis_arm_ir_to_arm_reg(ir_op->operands[1].reg);
 	op2 = subtilis_arm_ir_to_arm_reg(ir_op->operands[2].reg);
 
-	subtilis_arm_cmp(arm_p, itype, ccode, op1, op2, err);
+	subtilis_arm_add_cmp(arm_p, itype, ccode, op1, op2, err);
 }
 
 void subtilis_arm_gen_movii32(subtilis_ir_program_t *p, size_t start,
@@ -66,8 +66,8 @@ void subtilis_arm_gen_movii32(subtilis_ir_program_t *p, size_t start,
 
 	dest = subtilis_arm_ir_to_arm_reg(instr->operands[0].reg);
 
-	subtilis_arm_mov_imm(arm_p, SUBTILIS_ARM_CCODE_AL, false, dest, op2,
-			     err);
+	subtilis_arm_add_mov_imm(arm_p, SUBTILIS_ARM_CCODE_AL, false, dest, op2,
+				 err);
 }
 
 void subtilis_arm_gen_addii32(subtilis_ir_program_t *p, size_t start,
@@ -177,8 +177,8 @@ static void prv_stran_instr(subtilis_arm_instr_type_t itype,
 
 	dest = subtilis_arm_ir_to_arm_reg(instr->operands[0].reg);
 	base = subtilis_arm_ir_to_arm_reg(instr->operands[1].reg);
-	subtilis_arm_stran_imm(arm_p, itype, SUBTILIS_ARM_CCODE_AL, dest, base,
-			       offset, err);
+	subtilis_arm_add_stran_imm(arm_p, itype, SUBTILIS_ARM_CCODE_AL, dest,
+				   base, offset, err);
 }
 
 void subtilis_arm_gen_storeoi32(subtilis_ir_program_t *p, size_t start,
@@ -215,8 +215,8 @@ static void prv_cmp_jmp_imm(subtilis_ir_program_t *p, size_t start,
 
 	op1 = subtilis_arm_ir_to_arm_reg(cmp->operands[1].reg);
 
-	subtilis_arm_cmp_imm(arm_p, SUBTILIS_ARM_CCODE_AL, op1,
-			     cmp->operands[2].integer, err);
+	subtilis_arm_add_cmp_imm(arm_p, SUBTILIS_ARM_CCODE_AL, op1,
+				 cmp->operands[2].integer, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
 
@@ -354,16 +354,16 @@ static void prv_cmp_imm(subtilis_ir_program_t *p, size_t start, void *user_data,
 	subtilis_ir_inst_t *cmp = &p->ops[start]->op.instr;
 
 	op1 = subtilis_arm_ir_to_arm_reg(cmp->operands[1].reg);
-	subtilis_arm_cmp_imm(arm_p, SUBTILIS_ARM_CCODE_AL, op1,
-			     cmp->operands[2].integer, err);
+	subtilis_arm_add_cmp_imm(arm_p, SUBTILIS_ARM_CCODE_AL, op1,
+				 cmp->operands[2].integer, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
 
 	dest = subtilis_arm_ir_to_arm_reg(cmp->operands[0].reg);
-	subtilis_arm_mov_imm(arm_p, ok, false, dest, -1, err);
+	subtilis_arm_add_mov_imm(arm_p, ok, false, dest, -1, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
-	subtilis_arm_mov_imm(arm_p, nok, false, dest, 0, err);
+	subtilis_arm_add_mov_imm(arm_p, nok, false, dest, 0, err);
 }
 
 void subtilis_arm_gen_gtii32(subtilis_ir_program_t *p, size_t start,
@@ -422,10 +422,10 @@ static void prv_cmp(subtilis_ir_program_t *p, size_t start, void *user_data,
 		return;
 
 	dest = subtilis_arm_ir_to_arm_reg(cmp->operands[0].reg);
-	subtilis_arm_mov_imm(arm_p, ok, false, dest, -1, err);
+	subtilis_arm_add_mov_imm(arm_p, ok, false, dest, -1, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
-	subtilis_arm_mov_imm(arm_p, nok, false, dest, 0, err);
+	subtilis_arm_add_mov_imm(arm_p, nok, false, dest, 0, err);
 }
 
 void subtilis_arm_gen_gti32(subtilis_ir_program_t *p, size_t start,
@@ -500,7 +500,7 @@ void subtilis_arm_gen_jmpc(subtilis_ir_program_t *p, size_t start,
 
 	op1 = subtilis_arm_ir_to_arm_reg(jmp->operands[0].reg);
 
-	subtilis_arm_cmp_imm(arm_p, SUBTILIS_ARM_CCODE_AL, op1, 0, err);
+	subtilis_arm_add_cmp_imm(arm_p, SUBTILIS_ARM_CCODE_AL, op1, 0, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
 
@@ -561,8 +561,8 @@ void subtilis_arm_gen_mvni32(subtilis_ir_program_t *p, size_t start,
 	dest = subtilis_arm_ir_to_arm_reg(instr->operands[0].reg);
 	op2 = subtilis_arm_ir_to_arm_reg(instr->operands[1].reg);
 
-	subtilis_arm_mvn_reg(arm_p, SUBTILIS_ARM_CCODE_AL, false, dest, op2,
-			     err);
+	subtilis_arm_add_mvn_reg(arm_p, SUBTILIS_ARM_CCODE_AL, false, dest, op2,
+				 err);
 }
 
 void subtilis_arm_gen_andi32(subtilis_ir_program_t *p, size_t start,

--- a/arm_test.c
+++ b/arm_test.c
@@ -140,20 +140,20 @@ static void prv_add_ops(subtilis_arm_program_t *arm_p, subtilis_error_t *err)
 	dest.num = 0;
 	op1.num = 2;
 	op2.num = 1;
-	subtilis_arm_mov_reg(arm_p, SUBTILIS_ARM_CCODE_EQ, false, dest, op2,
-			     err);
+	subtilis_arm_add_mov_reg(arm_p, SUBTILIS_ARM_CCODE_EQ, false, dest, op2,
+				 err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
 
 	/* MVNSNE R0, r1 */
-	subtilis_arm_mov_reg(arm_p, SUBTILIS_ARM_CCODE_NE, true, dest, op2,
-			     err);
+	subtilis_arm_add_mov_reg(arm_p, SUBTILIS_ARM_CCODE_NE, true, dest, op2,
+				 err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
 
 	/* CMPGT R0, R1 */
-	subtilis_arm_cmp(arm_p, SUBTILIS_ARM_INSTR_CMP, SUBTILIS_ARM_CCODE_GT,
-			 dest, op2, err);
+	subtilis_arm_add_cmp(arm_p, SUBTILIS_ARM_INSTR_CMP,
+			     SUBTILIS_ARM_CCODE_GT, dest, op2, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
 
@@ -164,8 +164,8 @@ static void prv_add_ops(subtilis_arm_program_t *arm_p, subtilis_error_t *err)
 		return;
 
 	/* LDRCS R0, [R2, #16] */
-	subtilis_arm_stran_imm(arm_p, SUBTILIS_ARM_INSTR_LDR,
-			       SUBTILIS_ARM_CCODE_CS, dest, op1, 16, err);
+	subtilis_arm_add_stran_imm(arm_p, SUBTILIS_ARM_INSTR_LDR,
+				   SUBTILIS_ARM_CCODE_CS, dest, op1, 16, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
 

--- a/arm_test.c
+++ b/arm_test.c
@@ -14,8 +14,10 @@
  * limitations under the License.
  */
 
+#include <stdlib.h>
 #include <string.h>
 
+#include "arm_encode.h"
 #include "arm_test.h"
 #include "arm_vm.h"
 #include "parser_test.h"
@@ -110,11 +112,143 @@ static int prv_test_examples(void)
 	return ret;
 }
 
+/* clang-format off */
+static const uint32_t prv_expected_code[] = {
+	0x01A00001, /* MOVEQ R0, r1 */
+	0x11B00001, /* MVNSNE R0, r1 */
+	0xC1500001, /* CMPGT R0, R1 */
+	0xB0000192, /* MULLT R0, R2, R1 */
+	0x25920010, /* LDRCS R0, [R2, #16] */
+	0x3F0000DC, /* SWICS &DC */
+	0x4AFFFFFE, /* BMI #-8 */
+};
+
+/* clang-format on */
+
+static void prv_add_ops(subtilis_arm_program_t *arm_p, subtilis_error_t *err)
+{
+	subtilis_arm_reg_t dest;
+	subtilis_arm_reg_t op1;
+	subtilis_arm_reg_t op2;
+	subtilis_arm_instr_t *instr;
+
+	dest.type = SUBTILIS_ARM_REG_FIXED;
+	op1.type = SUBTILIS_ARM_REG_FIXED;
+	op2.type = SUBTILIS_ARM_REG_FIXED;
+
+	/* MOVEQ R0, r1 */
+	dest.num = 0;
+	op1.num = 2;
+	op2.num = 1;
+	subtilis_arm_mov_reg(arm_p, SUBTILIS_ARM_CCODE_EQ, false, dest, op2,
+			     err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	/* MVNSNE R0, r1 */
+	subtilis_arm_mov_reg(arm_p, SUBTILIS_ARM_CCODE_NE, true, dest, op2,
+			     err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	/* CMPGT R0, R1 */
+	subtilis_arm_cmp(arm_p, SUBTILIS_ARM_INSTR_CMP, SUBTILIS_ARM_CCODE_GT,
+			 dest, op2, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	/* MULLT R0, R2, R1 */
+	subtilis_arm_add_mul(arm_p, SUBTILIS_ARM_CCODE_LT, false, dest, op1,
+			     op2, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	/* LDRCS R0, [R2, #16] */
+	subtilis_arm_stran_imm(arm_p, SUBTILIS_ARM_INSTR_LDR,
+			       SUBTILIS_ARM_CCODE_CS, dest, op1, 16, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	/* SWINV &DC */
+	instr =
+	    subtilis_arm_program_add_instr(arm_p, SUBTILIS_ARM_INSTR_SWI, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	instr->operands.swi.ccode = SUBTILIS_ARM_CCODE_CC;
+	instr->operands.swi.code = 0xdc;
+
+	subtilis_arm_program_add_label(arm_p, 0, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	/* BMI label_0 */
+	instr =
+	    subtilis_arm_program_add_instr(arm_p, SUBTILIS_ARM_INSTR_B, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+	instr->operands.br.ccode = SUBTILIS_ARM_CCODE_MI;
+	instr->operands.br.label = 0;
+}
+
+static int prv_test_encode(void)
+{
+	subtilis_error_t err;
+	int retval = 1;
+	subtilis_arm_op_pool_t *pool = NULL;
+	subtilis_arm_program_t *arm_p = NULL;
+	uint32_t *code = NULL;
+	size_t i;
+
+	printf("arm_test_encode");
+
+	subtilis_error_init(&err);
+	pool = subtilis_arm_op_pool_new(&err);
+	if (err.type != SUBTILIS_ERROR_OK)
+		goto cleanup;
+
+	arm_p = subtilis_arm_program_new(pool, 16, 0, 0, &err);
+	if (err.type != SUBTILIS_ERROR_OK)
+		goto cleanup;
+
+	prv_add_ops(arm_p, &err);
+	if (err.type != SUBTILIS_ERROR_OK)
+		goto cleanup;
+
+	code = subtilis_arm_encode_buf(arm_p, &err);
+	if (err.type != SUBTILIS_ERROR_OK)
+		goto cleanup;
+
+	for (i = 0; i < sizeof(prv_expected_code) / sizeof(uint32_t); i++)
+		if (code[i] != prv_expected_code[i]) {
+			fprintf(stderr, "%zu: expected 0x%x got 0x%x\n", i,
+				prv_expected_code[i], code[i]);
+			goto cleanup;
+		}
+
+	retval = 0;
+
+cleanup:
+	if (err.type != SUBTILIS_ERROR_OK) {
+		printf(": [FAIL]\n");
+		subtilis_error_fprintf(stdout, &err, true);
+	} else {
+		printf(": [OK]\n");
+	}
+
+	free(code);
+	subtilis_arm_program_delete(arm_p);
+	subtilis_arm_op_pool_delete(pool);
+
+	return retval;
+}
+
 int arm_test(void)
 {
 	int res;
 
 	res = prv_test_examples();
+	res |= prv_test_encode();
 
 	return res;
 }

--- a/arm_test.c
+++ b/arm_test.c
@@ -170,13 +170,9 @@ static void prv_add_ops(subtilis_arm_program_t *arm_p, subtilis_error_t *err)
 		return;
 
 	/* SWINV &DC */
-	instr =
-	    subtilis_arm_program_add_instr(arm_p, SUBTILIS_ARM_INSTR_SWI, err);
+	subtilis_arm_add_swi(arm_p, SUBTILIS_ARM_CCODE_CC, 0xdc, 0, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
-
-	instr->operands.swi.ccode = SUBTILIS_ARM_CCODE_CC;
-	instr->operands.swi.code = 0xdc;
 
 	subtilis_arm_program_add_label(arm_p, 0, err);
 	if (err->type != SUBTILIS_ERROR_OK)

--- a/riscos_arm.c
+++ b/riscos_arm.c
@@ -49,8 +49,8 @@ static size_t prv_add_preamble(subtilis_arm_program_t *arm_p,
 	dest.num = 13;
 	op2.type = SUBTILIS_ARM_REG_FIXED;
 	op2.num = 12;
-	subtilis_arm_mov_reg(arm_p, SUBTILIS_ARM_CCODE_AL, false, dest, op2,
-			     err);
+	subtilis_arm_add_mov_reg(arm_p, SUBTILIS_ARM_CCODE_AL, false, dest, op2,
+				 err);
 	return label;
 }
 
@@ -60,18 +60,20 @@ static void prv_add_coda(subtilis_arm_program_t *arm_p, subtilis_error_t *err)
 
 	dest.type = SUBTILIS_ARM_REG_FIXED;
 	dest.num = 0;
-	subtilis_arm_mov_imm(arm_p, SUBTILIS_ARM_CCODE_AL, false, dest, 0, err);
+	subtilis_arm_add_mov_imm(arm_p, SUBTILIS_ARM_CCODE_AL, false, dest, 0,
+				 err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
 
 	dest.num = 1;
-	subtilis_arm_mov_imm(arm_p, SUBTILIS_ARM_CCODE_AL, false, dest,
-			     0x58454241, err);
+	subtilis_arm_add_mov_imm(arm_p, SUBTILIS_ARM_CCODE_AL, false, dest,
+				 0x58454241, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
 
 	dest.num = 2;
-	subtilis_arm_mov_imm(arm_p, SUBTILIS_ARM_CCODE_AL, false, dest, 0, err);
+	subtilis_arm_add_mov_imm(arm_p, SUBTILIS_ARM_CCODE_AL, false, dest, 0,
+				 err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
 
@@ -168,8 +170,8 @@ void subtilis_riscos_arm_printi(subtilis_ir_program_t *p, size_t start,
 	dest.num = 0;
 	op2 = subtilis_arm_ir_to_arm_reg(printi->operands[0].reg);
 
-	subtilis_arm_mov_reg(arm_p, SUBTILIS_ARM_CCODE_AL, false, dest, op2,
-			     err);
+	subtilis_arm_add_mov_reg(arm_p, SUBTILIS_ARM_CCODE_AL, false, dest, op2,
+				 err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
 
@@ -183,8 +185,8 @@ void subtilis_riscos_arm_printi(subtilis_ir_program_t *p, size_t start,
 		return;
 
 	dest.num = 2;
-	subtilis_arm_mov_imm(arm_p, SUBTILIS_ARM_CCODE_AL, false, dest,
-			     SUBTILIS_RISCOS_PRINT_BUFFER_SIZE, err);
+	subtilis_arm_add_mov_imm(arm_p, SUBTILIS_ARM_CCODE_AL, false, dest,
+				 SUBTILIS_RISCOS_PRINT_BUFFER_SIZE, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
 

--- a/riscos_arm.c
+++ b/riscos_arm.c
@@ -22,20 +22,15 @@
 static size_t prv_add_preamble(subtilis_arm_program_t *arm_p,
 			       subtilis_error_t *err)
 {
-	subtilis_arm_instr_t *instr;
 	subtilis_arm_reg_t dest;
 	subtilis_arm_reg_t op1;
 	subtilis_arm_reg_t op2;
 	size_t label;
 
-	instr =
-	    subtilis_arm_program_add_instr(arm_p, SUBTILIS_ARM_INSTR_SWI, err);
+	/* 0x7 = R0, R1, R2 */
+	subtilis_arm_add_swi(arm_p, SUBTILIS_ARM_CCODE_AL, 0x10, 0x7, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return 0;
-
-	instr->operands.swi.ccode = SUBTILIS_ARM_CCODE_AL;
-	instr->operands.swi.code = 0x10;
-	instr->operands.swi.reg_mask = 0x7; // R0, R1, R2
 
 	// TODO we need to check that the globals are not too big
 	// for the amount of memory we have been allocated by the OS
@@ -61,7 +56,6 @@ static size_t prv_add_preamble(subtilis_arm_program_t *arm_p,
 
 static void prv_add_coda(subtilis_arm_program_t *arm_p, subtilis_error_t *err)
 {
-	subtilis_arm_instr_t *instr;
 	subtilis_arm_reg_t dest;
 
 	dest.type = SUBTILIS_ARM_REG_FIXED;
@@ -80,14 +74,10 @@ static void prv_add_coda(subtilis_arm_program_t *arm_p, subtilis_error_t *err)
 	subtilis_arm_mov_imm(arm_p, SUBTILIS_ARM_CCODE_AL, false, dest, 0, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
-	instr =
-	    subtilis_arm_program_add_instr(arm_p, SUBTILIS_ARM_INSTR_SWI, err);
+
+	subtilis_arm_add_swi(arm_p, SUBTILIS_ARM_CCODE_AL, 0x11, 0, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
-
-	instr->operands.swi.ccode = SUBTILIS_ARM_CCODE_AL;
-	instr->operands.swi.code = 0x11;
-	instr->operands.swi.reg_mask = 0;
 }
 
 /* clang-format off */
@@ -168,7 +158,6 @@ cleanup:
 void subtilis_riscos_arm_printi(subtilis_ir_program_t *p, size_t start,
 				void *user_data, subtilis_error_t *err)
 {
-	subtilis_arm_instr_t *instr;
 	subtilis_arm_reg_t dest;
 	subtilis_arm_reg_t op1;
 	subtilis_arm_reg_t op2;
@@ -199,24 +188,16 @@ void subtilis_riscos_arm_printi(subtilis_ir_program_t *p, size_t start,
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
 
-	instr =
-	    subtilis_arm_program_add_instr(arm_p, SUBTILIS_ARM_INSTR_SWI, err);
+	// 0x7 = r0, r1, r2
+	subtilis_arm_add_swi(arm_p, SUBTILIS_ARM_CCODE_AL, 0xdc, 0x7, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
 
-	instr->operands.swi.ccode = SUBTILIS_ARM_CCODE_AL;
-	instr->operands.swi.code = 0xdc;
-	instr->operands.swi.reg_mask = 0x7; // r0, r1, r2
-
-	instr = subtilis_arm_program_dup_instr(arm_p, err);
+	subtilis_arm_add_swi(arm_p, SUBTILIS_ARM_CCODE_AL, 0x2, 0, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
-	instr->operands.swi.code = 0x2;
-	instr->operands.swi.reg_mask = 0;
 
-	instr = subtilis_arm_program_dup_instr(arm_p, err);
+	subtilis_arm_add_swi(arm_p, SUBTILIS_ARM_CCODE_AL, 0x3, 0, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
-	instr->operands.swi.code = 0x3;
-	instr->operands.swi.reg_mask = 0;
 }


### PR DESCRIPTION
This PR fixes a number of issues:

1. The MUL function was encoded incorrectly.
2. There was a memory encoding issue when encoding labels.
3. Added a convenience function for adding SWI commands and renamed some functions.