### PR TITLE
Add separate data structure for MUL

### DIFF
--- a/arm_core.h
+++ b/arm_core.h
@@ -127,6 +127,17 @@ struct subtilis_arm_data_instr_t_ {
 
 typedef struct subtilis_arm_data_instr_t_ subtilis_arm_data_instr_t;
 
+struct subtilis_arm_mul_instr_t_ {
+	subtilis_arm_ccode_type_t ccode;
+	bool status;
+	subtilis_arm_reg_t dest;
+	subtilis_arm_reg_t rm;
+	subtilis_arm_reg_t rs;
+	subtilis_arm_reg_t rn;
+};
+
+typedef struct subtilis_arm_mul_instr_t_ subtilis_arm_mul_instr_t;
+
 struct subtilis_arm_stran_instr_t_ {
 	subtilis_arm_ccode_type_t ccode;
 	subtilis_arm_reg_t dest;
@@ -177,6 +188,7 @@ struct subtilis_arm_instr_t_ {
 	subtilis_arm_instr_type_t type;
 	union {
 		subtilis_arm_data_instr_t data;
+		subtilis_arm_mul_instr_t mul;
 		subtilis_arm_stran_instr_t stran;
 		subtilis_arm_mtran_instr_t mtran;
 		subtilis_arm_br_instr_t br;
@@ -280,12 +292,12 @@ void subtilis_arm_add_rsub_imm(subtilis_arm_program_t *p,
 			       int32_t op2, subtilis_error_t *err);
 void subtilis_arm_add_mul_imm(subtilis_arm_program_t *p,
 			      subtilis_arm_ccode_type_t ccode, bool status,
-			      subtilis_arm_reg_t dest, subtilis_arm_reg_t op1,
-			      int32_t op2, subtilis_error_t *err);
+			      subtilis_arm_reg_t dest, subtilis_arm_reg_t rm,
+			      int32_t rs, subtilis_error_t *err);
 void subtilis_arm_add_mul(subtilis_arm_program_t *p,
 			  subtilis_arm_ccode_type_t ccode, bool status,
-			  subtilis_arm_reg_t dest, subtilis_arm_reg_t op1,
-			  subtilis_arm_reg_t op2, subtilis_error_t *err);
+			  subtilis_arm_reg_t dest, subtilis_arm_reg_t rm,
+			  subtilis_arm_reg_t rs, subtilis_error_t *err);
 void subtilis_arm_add_data_imm(subtilis_arm_program_t *p,
 			       subtilis_arm_instr_type_t itype,
 			       subtilis_arm_ccode_type_t ccode, bool status,

--- a/arm_vm.c
+++ b/arm_vm.c
@@ -475,21 +475,15 @@ static void prv_process_mvn(subtilis_arm_vm_t *arm_vm,
 }
 
 static void prv_process_mul(subtilis_arm_vm_t *arm_vm,
-			    subtilis_arm_data_instr_t *op,
-			    subtilis_error_t *err)
+			    subtilis_arm_mul_instr_t *op, subtilis_error_t *err)
 {
-	int32_t op2;
-
 	if (!prv_match_ccode(arm_vm, op->ccode)) {
 		arm_vm->regs[15] += 4;
 		return;
 	}
 
-	op2 = prv_eval_op2(arm_vm, op->status, &op->op2, err);
-	if (err->type != SUBTILIS_ERROR_OK)
-		return;
-
-	arm_vm->regs[op->dest.num] = arm_vm->regs[op->op1.num] * op2;
+	arm_vm->regs[op->dest.num] =
+	    arm_vm->regs[op->rm.num] * arm_vm->regs[op->rs.num];
 	arm_vm->regs[15] += 4;
 }
 
@@ -690,7 +684,7 @@ void subtilis_arm_vm_run(subtilis_arm_vm_t *arm_vm, subtilis_buffer_t *b,
 					err);
 			break;
 		case SUBTILIS_ARM_INSTR_MUL:
-			prv_process_mul(arm_vm, &op->op.instr.operands.data,
+			prv_process_mul(arm_vm, &op->op.instr.operands.mul,
 					err);
 			break;
 		case SUBTILIS_ARM_INSTR_LDR:

--- a/arm_walker.c
+++ b/arm_walker.c
@@ -36,10 +36,13 @@ static void prv_walk_instr(subtlis_arm_walker_t *walker, subtilis_arm_op_t *op,
 	case SUBTILIS_ARM_INSTR_TEQ:
 	case SUBTILIS_ARM_INSTR_ORR:
 	case SUBTILIS_ARM_INSTR_BIC:
-	case SUBTILIS_ARM_INSTR_MUL:
-	case SUBTILIS_ARM_INSTR_MLA:
 		walker->data_fn(walker->user_data, op, instr->type,
 				&instr->operands.data, err);
+		break;
+	case SUBTILIS_ARM_INSTR_MUL:
+	case SUBTILIS_ARM_INSTR_MLA:
+		walker->mul_fn(walker->user_data, op, instr->type,
+			       &instr->operands.mul, err);
 		break;
 	case SUBTILIS_ARM_INSTR_CMP:
 	case SUBTILIS_ARM_INSTR_CMN:

--- a/arm_walker.h
+++ b/arm_walker.h
@@ -32,6 +32,9 @@ struct subtlis_arm_walker_t_ {
 			subtilis_arm_instr_type_t type,
 			subtilis_arm_data_instr_t *instr,
 			subtilis_error_t *err);
+	void (*mul_fn)(void *user_data, subtilis_arm_op_t *op,
+		       subtilis_arm_instr_type_t type,
+		       subtilis_arm_mul_instr_t *instr, subtilis_error_t *err);
 	void (*cmp_fn)(void *user_data, subtilis_arm_op_t *op,
 		       subtilis_arm_instr_type_t type,
 		       subtilis_arm_data_instr_t *instr, subtilis_error_t *err);


### PR DESCRIPTION
The abstraction of the ARM MUL and MLA instructions was using the
structure for the data instructions, which was incorrect.  This has
been fixed by adding a new structure to represent MUL and updating
the walkers.

Signed-off-by: Mark Ryan <markusdryan@gmail.com>