### PR TITLE
Actually build the compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ install:
  - wget https://raw.githubusercontent.com/torvalds/linux/master/scripts/const_structs.checkpatch
 
 script:
+ - CFLAGS="-g -fsanitize=address -fno-omit-frame-pointer -Wall -Werror" make
  - CFLAGS="-g -fsanitize=address -fno-omit-frame-pointer -Wall -Werror" make check
  - perl checkpatch.pl --no-tree -f --strict --show-types --ignore NEW_TYPEDEFS --ignore PREFER_KERNEL_TYPES --ignore SPLIT_STRING --ignore UNNECESSARY_PARENTHESES --ignore OPEN_ENDED_LINE *.c *.h
  - ./check-format.sh


### PR DESCRIPTION
The travis script only builds and runs the unit tests.  It doesn't actually,
build the compiler.  This commit fixes that.

Signed-off-by: Mark Ryan <markusdryan@gmail.com>