### PR TITLE
Cleanup the branch instruction

### DIFF
--- a/arm_core.c
+++ b/arm_core.c
@@ -1315,11 +1315,12 @@ static void prv_dump_br_instr(void *user_data, subtilis_arm_op_t *op,
 		printf("%s", ccode_desc[instr->ccode]);
 	if (instr->link) {
 		if (p)
-			printf(" %s\n", p->string_pool->strings[instr->label]);
+			printf(" %s\n",
+			       p->string_pool->strings[instr->target.label]);
 		else
 			printf("\n");
 	} else {
-		printf(" label_%zu\n", instr->label);
+		printf(" label_%zu\n", instr->target.label);
 	}
 }
 

--- a/arm_core.h
+++ b/arm_core.h
@@ -175,12 +175,13 @@ struct subtilis_arm_mtran_instr_t_ {
 
 typedef struct subtilis_arm_mtran_instr_t_ subtilis_arm_mtran_instr_t;
 
-/* TODO, We need a union for the label */
 struct subtilis_arm_br_instr_t_ {
 	subtilis_arm_ccode_type_t ccode;
 	bool link;
-	size_t label;
-	int32_t offset;
+	union {
+		size_t label;
+		int32_t offset;
+	} target;
 };
 
 typedef struct subtilis_arm_br_instr_t_ subtilis_arm_br_instr_t;

--- a/arm_core.h
+++ b/arm_core.h
@@ -112,7 +112,6 @@ typedef enum {
 	SUBTILIS_ARM_INSTR_LDM,
 	SUBTILIS_ARM_INSTR_STM,
 	SUBTILIS_ARM_INSTR_B,
-	SUBTILIS_ARM_INSTR_BL,
 	SUBTILIS_ARM_INSTR_SWI,
 	SUBTILIS_ARM_INSTR_LDRC,
 } subtilis_arm_instr_type_t;
@@ -176,7 +175,7 @@ struct subtilis_arm_mtran_instr_t_ {
 
 typedef struct subtilis_arm_mtran_instr_t_ subtilis_arm_mtran_instr_t;
 
-/* TODO, we don't need link here, and we need a union for the label */
+/* TODO, We need a union for the label */
 struct subtilis_arm_br_instr_t_ {
 	subtilis_arm_ccode_type_t ccode;
 	bool link;

--- a/arm_disass.c
+++ b/arm_disass.c
@@ -57,14 +57,8 @@ static void prv_decode_branch(subtilis_arm_instr_t *instr, uint32_t encoded,
 {
 	subtilis_arm_br_instr_t *br = &instr->operands.br;
 
-	if (encoded & (1 << 24)) {
-		instr->type = SUBTILIS_ARM_INSTR_BL;
-		br->link = true;
-	} else {
-		instr->type = SUBTILIS_ARM_INSTR_B;
-		br->link = false;
-	}
-
+	instr->type = SUBTILIS_ARM_INSTR_B;
+	br->link = (encoded & (1 << 24));
 	br->ccode = (encoded >> 28);
 	br->offset = encoded & 0xffffff;
 	if (encoded & 0x800000)

--- a/arm_disass.c
+++ b/arm_disass.c
@@ -60,9 +60,9 @@ static void prv_decode_branch(subtilis_arm_instr_t *instr, uint32_t encoded,
 	instr->type = SUBTILIS_ARM_INSTR_B;
 	br->link = (encoded & (1 << 24));
 	br->ccode = (encoded >> 28);
-	br->offset = encoded & 0xffffff;
+	br->target.offset = encoded & 0xffffff;
 	if (encoded & 0x800000)
-		br->offset = encoded | 0xff000000;
+		br->target.offset = encoded | 0xff000000;
 }
 
 static void prv_decode_mtran(subtilis_arm_instr_t *instr, uint32_t encoded,

--- a/arm_encode.c
+++ b/arm_encode.c
@@ -428,9 +428,9 @@ static void prv_encode_br_instr(void *user_data, subtilis_arm_op_t *op,
 	if (instr->link) {
 		word |= 1 << 24;
 		subtilis_arm_link_add(ud->link, ud->words_written, err);
-		word |= instr->label;
+		word |= instr->target.label;
 	} else {
-		prv_add_back_patch(ud, instr->label, ud->words_written,
+		prv_add_back_patch(ud, instr->target.label, ud->words_written,
 				   SUBTILIS_ARM_ENCODE_BP_BR, err);
 	}
 	if (err->type != SUBTILIS_ERROR_OK)

--- a/arm_gen.c
+++ b/arm_gen.c
@@ -228,7 +228,7 @@ static void prv_cmp_jmp_imm(subtilis_ir_section_t *s, size_t start,
 	br = &instr->operands.br;
 	br->ccode = ccode;
 	br->link = false;
-	br->label = jmp->operands[2].label;
+	br->target.label = jmp->operands[2].label;
 }
 
 void subtilis_arm_gen_if_lt_imm(subtilis_ir_section_t *s, size_t start,
@@ -305,7 +305,7 @@ static void prv_cmp_jmp(subtilis_ir_section_t *s, size_t start, void *user_data,
 	br = &instr->operands.br;
 	br->ccode = ccode;
 	br->link = false;
-	br->label = jmp->operands[2].label;
+	br->target.label = jmp->operands[2].label;
 }
 
 void subtilis_arm_gen_if_lt(subtilis_ir_section_t *s, size_t start,
@@ -486,7 +486,7 @@ void subtilis_arm_gen_jump(subtilis_ir_section_t *s, size_t start,
 	br = &instr->operands.br;
 	br->ccode = SUBTILIS_ARM_CCODE_AL;
 	br->link = false;
-	br->label = jmp->operands[0].label;
+	br->target.label = jmp->operands[0].label;
 }
 
 void subtilis_arm_gen_jmpc(subtilis_ir_section_t *s, size_t start,
@@ -512,7 +512,7 @@ void subtilis_arm_gen_jmpc(subtilis_ir_section_t *s, size_t start,
 	br = &instr->operands.br;
 	br->ccode = SUBTILIS_ARM_CCODE_EQ;
 	br->link = false;
-	br->label = jmp->operands[2].label;
+	br->target.label = jmp->operands[2].label;
 }
 
 void subtilis_arm_gen_eorii32(subtilis_ir_section_t *s, size_t start,
@@ -598,7 +598,7 @@ void subtilis_arm_gen_call(subtilis_ir_section_t *s, size_t start,
 	br = &instr->operands.br;
 	br->ccode = SUBTILIS_ARM_CCODE_AL;
 	br->link = true;
-	br->label = ir_instr->operands[0].label;
+	br->target.label = ir_instr->operands[0].label;
 
 	subtilis_arm_section_add_call_site(arm_s, arm_s->last_op, err);
 	if (err->type != SUBTILIS_ERROR_OK)

--- a/arm_test.c
+++ b/arm_test.c
@@ -205,7 +205,7 @@ static void prv_add_ops(subtilis_arm_section_t *arm_s, subtilis_error_t *err)
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
 	instr->operands.br.ccode = SUBTILIS_ARM_CCODE_MI;
-	instr->operands.br.label = 0;
+	instr->operands.br.target.label = 0;
 
 	/* LDMFA R7!, {R0} */
 	dest.num = 7;
@@ -664,9 +664,9 @@ static int prv_test_disass_b(void)
 		return 1;
 	}
 
-	if (br->offset != -2) {
+	if (br->target.offset != -2) {
 		fprintf(stderr, "[6] offset of -2 expected got %d\n",
-			br->offset);
+			br->target.offset);
 		return 1;
 	}
 

--- a/arm_vm.c
+++ b/arm_vm.c
@@ -502,7 +502,7 @@ static void prv_process_b(subtilis_arm_vm_t *arm_vm,
 	if (op->link)
 		arm_vm->regs[14] = arm_vm->regs[15];
 
-	arm_vm->regs[15] += (op->offset * 4) + 8;
+	arm_vm->regs[15] += (op->target.offset * 4) + 8;
 	if (prv_calc_pc(arm_vm) >= arm_vm->code_size)
 		subtilis_error_set_assertion_failed(err);
 }

--- a/arm_vm.c
+++ b/arm_vm.c
@@ -499,19 +499,9 @@ static void prv_process_b(subtilis_arm_vm_t *arm_vm,
 		return;
 	}
 
-	arm_vm->regs[15] += (op->offset * 4) + 8;
-	if (prv_calc_pc(arm_vm) >= arm_vm->code_size)
-		subtilis_error_set_assertion_failed(err);
-}
+	if (op->link)
+		arm_vm->regs[14] = arm_vm->regs[15];
 
-static void prv_process_bl(subtilis_arm_vm_t *arm_vm,
-			   subtilis_arm_br_instr_t *op, subtilis_error_t *err)
-{
-	if (!prv_match_ccode(arm_vm, op->ccode)) {
-		arm_vm->regs[15] += 4;
-		return;
-	}
-	arm_vm->regs[14] = arm_vm->regs[15];
 	arm_vm->regs[15] += (op->offset * 4) + 8;
 	if (prv_calc_pc(arm_vm) >= arm_vm->code_size)
 		subtilis_error_set_assertion_failed(err);
@@ -746,9 +736,6 @@ void subtilis_arm_vm_run(subtilis_arm_vm_t *arm_vm, subtilis_buffer_t *b,
 			break;
 		case SUBTILIS_ARM_INSTR_B:
 			prv_process_b(arm_vm, &instr.operands.br, err);
-			break;
-		case SUBTILIS_ARM_INSTR_BL:
-			prv_process_bl(arm_vm, &instr.operands.br, err);
 			break;
 		case SUBTILIS_ARM_INSTR_SWI:
 			prv_process_swi(arm_vm, b, &instr.operands.swi, err);

--- a/arm_walker.c
+++ b/arm_walker.c
@@ -65,7 +65,6 @@ static void prv_walk_instr(subtlis_arm_walker_t *walker, subtilis_arm_op_t *op,
 				 &instr->operands.mtran, err);
 		break;
 	case SUBTILIS_ARM_INSTR_B:
-	case SUBTILIS_ARM_INSTR_BL:
 		walker->br_fn(walker->user_data, op, instr->type,
 			      &instr->operands.br, err);
 		break;


### PR DESCRIPTION
- Add a union to represent the two different types of targets in subtilis_arm_br_instr_t.
- Remove the SUBTILIS_ARM_INSTR_BL instruction