### PR TITLE
Store local variables in regsiters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,35 @@
 language: c
 
+before_install:
+    - eval "${MATRIX_EVAL}"
+
+matrix:
+  include:
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-4.9
+      env:
+        - MATRIX_EVAL="CC=gcc-4.9 && CXX=g++-4.9"
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - llvm-toolchain-trusty-4.0
+          packages:
+            - clang-4.0
+      env:
+        - MATRIX_EVAL="CC=clang-4.0 && CXX=clang++-4.0"
+
 before_script:
   - echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main" | sudo tee -a /etc/apt/sources.list
   - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
   - sudo apt-get update -qq
   - sudo apt-get install clang-format-3.9 -y
 
-compiler:
-  - clang
-  - gcc
 
 install:
  - wget https://raw.githubusercontent.com/torvalds/linux/master/scripts/checkpatch.pl

--- a/arm_gen.c
+++ b/arm_gen.c
@@ -576,7 +576,7 @@ void subtilis_arm_gen_call(subtilis_ir_section_t *s, size_t start,
 			   void *user_data, subtilis_error_t *err)
 {
 	subtilis_arm_reg_t op0;
-	subtilis_ir_inst_t *ir_instr = &s->ops[start]->op.instr;
+	subtilis_ir_call_t *call = &s->ops[start]->op.call;
 	subtilis_arm_instr_t *instr;
 	subtilis_arm_section_t *arm_s = user_data;
 	subtilis_arm_br_instr_t *br;
@@ -598,7 +598,7 @@ void subtilis_arm_gen_call(subtilis_ir_section_t *s, size_t start,
 	br = &instr->operands.br;
 	br->ccode = SUBTILIS_ARM_CCODE_AL;
 	br->link = true;
-	br->target.label = ir_instr->operands[0].label;
+	br->target.label = call->proc_id;
 
 	subtilis_arm_section_add_call_site(arm_s, arm_s->last_op, err);
 	if (err->type != SUBTILIS_ERROR_OK)

--- a/arm_gen.c
+++ b/arm_gen.c
@@ -56,6 +56,21 @@ static void prv_cmp_simple(subtilis_ir_section_t *s, size_t start,
 	subtilis_arm_add_cmp(arm_s, itype, ccode, op1, op2, err);
 }
 
+void subtilis_arm_gen_mov(subtilis_ir_section_t *s, size_t start,
+			  void *user_data, subtilis_error_t *err)
+{
+	subtilis_arm_reg_t dest;
+	subtilis_arm_section_t *arm_s = user_data;
+	subtilis_ir_inst_t *instr = &s->ops[start]->op.instr;
+	subtilis_arm_reg_t op2;
+
+	dest = subtilis_arm_ir_to_arm_reg(instr->operands[0].reg);
+	op2 = subtilis_arm_ir_to_arm_reg(instr->operands[1].reg);
+
+	subtilis_arm_add_mov_reg(arm_s, SUBTILIS_ARM_CCODE_AL, false, dest, op2,
+				 err);
+}
+
 void subtilis_arm_gen_movii32(subtilis_ir_section_t *s, size_t start,
 			      void *user_data, subtilis_error_t *err)
 {

--- a/arm_gen.h
+++ b/arm_gen.h
@@ -19,6 +19,8 @@
 
 #include "ir.h"
 
+void subtilis_arm_gen_mov(subtilis_ir_section_t *s, size_t start,
+			  void *user_data, subtilis_error_t *err);
 void subtilis_arm_gen_movii32(subtilis_ir_section_t *s, size_t start,
 			      void *user_data, subtilis_error_t *err);
 void subtilis_arm_gen_addii32(subtilis_ir_section_t *s, size_t start,

--- a/error.c
+++ b/error.c
@@ -74,11 +74,11 @@ static subtilis_error_desc_t prv_errors[] = {
 	/* SUBTILIS_ERROR_KEYWORD_EXPECTED */
 	{"Keyword expected, found %s.\n", 1},
 
-	/* SUBTILIS_ERROR_NOT_SUPPORTED */
-	{"Keyword %s not supported.\n", 1},
-
 	/* SUBTILIS_ID_EXPECTED */
 	{"Identifer expected found %s.\n", 1},
+
+	/* SUBTILIS_ERROR_NOT_SUPPORTED */
+	{"%s not supported.\n", 1},
 
 	/* SUBTILIS_ERROR_ASSIGNMENT_OP_EXPECTED */
 	{"Assignment operator (=, +=, -=)  expected found %s.\n", 1},

--- a/ir.h
+++ b/ir.h
@@ -38,6 +38,7 @@ enum {
 typedef enum {
 	SUBTILIS_OP_INSTR,
 	SUBTILIS_OP_LABEL,
+	SUBTILIS_OP_CALL,
 	SUBTILIS_OP_PHI,
 	SUBTILIS_OP_MAX,
 } subtilis_op_type_t;
@@ -642,17 +643,6 @@ typedef enum {
 	SUBTILIS_OP_INSTR_JMP,
 
 	/*
-	 * CALL label
-	 *
-	 * inovkes a function identified by an integer.  The integer
-	 * is an indexed into the string pool of the program of which
-	 * this code section is a part.
-	 *
-	 */
-
-	SUBTILIS_OP_INSTR_CALL,
-
-	/*
 	 * RET
 	 *
 	 * returns from a sub-routine call.
@@ -695,11 +685,25 @@ struct subtilis_ir_inst_t_ {
 
 typedef struct subtilis_ir_inst_t_ subtilis_ir_inst_t;
 
+union subtilis_ir_arg_t_ {
+};
+
+typedef union subtilis_ir_arg_t_ subtilis_ir_arg_t;
+
+struct subtilis_ir_call_t_ {
+	size_t proc_id;
+	size_t arg_count;
+	subtilis_ir_arg_t *args;
+};
+
+typedef struct subtilis_ir_call_t_ subtilis_ir_call_t;
+
 struct subtilis_ir_op_t_ {
 	subtilis_op_type_t type;
 	union {
 		subtilis_ir_inst_t instr;
 		size_t label;
+		subtilis_ir_call_t call;
 	} op;
 };
 
@@ -815,6 +819,10 @@ void subtilis_ir_section_dump(subtilis_ir_section_t *s);
 size_t subtilis_ir_section_new_label(subtilis_ir_section_t *s);
 void subtilis_ir_section_add_label(subtilis_ir_section_t *s, size_t l,
 				   subtilis_error_t *err);
+/* Ownership of args passes to this function */
+void subtilis_ir_section_add_call(subtilis_ir_section_t *s, size_t id,
+				  size_t arg_count, subtilis_ir_arg_t *args,
+				  subtilis_error_t *err);
 void subtilis_ir_parse_rules(const subtilis_ir_rule_raw_t *raw,
 			     subtilis_ir_rule_t *parsed, size_t count,
 			     subtilis_error_t *err);

--- a/parser.c
+++ b/parser.c
@@ -1057,7 +1057,6 @@ static void prv_proc(subtilis_parser_t *p, subtilis_token_t *t,
 		     subtilis_error_t *err)
 {
 	const char *tbuf;
-	subtilis_ir_operand_t op;
 	subtilis_parser_call_t *call = NULL;
 	subtilis_type_section_t *stype = NULL;
 
@@ -1070,9 +1069,7 @@ static void prv_proc(subtilis_parser_t *p, subtilis_token_t *t,
 	tbuf = subtilis_token_get_text(t);
 	tbuf += 4;
 
-	op.integer = 0;
-	subtilis_ir_section_add_instr_no_reg(p->current, SUBTILIS_OP_INSTR_CALL,
-					     op, err);
+	subtilis_ir_section_add_call(p->current, 0, 0, NULL, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		goto on_error;
 
@@ -1163,7 +1160,7 @@ static void prv_check_call(subtilis_parser_t *p, subtilis_parser_call_t *call,
 		return;
 	}
 
-	call->s->ops[call->index]->op.instr.operands[0].integer = index;
+	call->s->ops[call->index]->op.call.proc_id = index;
 }
 
 static void prv_check_calls(subtilis_parser_t *p, subtilis_error_t *err)

--- a/parser.c
+++ b/parser.c
@@ -188,11 +188,15 @@ static subtilis_exp_t *prv_variable(subtilis_parser_t *p, subtilis_token_t *t,
 		    err, tbuf, p->l->stream->name, p->l->line);
 		return NULL;
 	}
-	op2.integer = s->loc;
-	reg = subtilis_ir_section_add_instr(
-	    p->current, SUBTILIS_OP_INSTR_LOADO_I32, op1, op2, err);
-	if (err->type != SUBTILIS_ERROR_OK)
-		return NULL;
+	if (!s->is_reg) {
+		op2.integer = s->loc;
+		reg = subtilis_ir_section_add_instr(
+		    p->current, SUBTILIS_OP_INSTR_LOADO_I32, op1, op2, err);
+		if (err->type != SUBTILIS_ERROR_OK)
+			return NULL;
+	} else {
+		reg = s->loc;
+	}
 	return subtilis_exp_new_var(SUBTILIS_EXP_INTEGER, reg, err);
 }
 
@@ -548,16 +552,99 @@ static subtilis_exp_t *prv_expression(subtilis_parser_t *p, subtilis_token_t *t,
 	return prv_priority7(p, t, err);
 }
 
+static void prv_assign_to_reg(subtilis_parser_t *p, subtilis_token_t *t,
+			      const char *tbuf, size_t loc,
+			      subtilis_error_t *err)
+{
+	subtilis_op_instr_type_t instr;
+	subtilis_ir_operand_t op0;
+	subtilis_ir_operand_t op2;
+	subtilis_exp_t *e = NULL;
+
+	e = prv_expression(p, t, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	switch (e->type) {
+	case SUBTILIS_EXP_CONST_INTEGER:
+		instr = SUBTILIS_OP_INSTR_MOVI_I32;
+		break;
+	case SUBTILIS_EXP_INTEGER:
+		instr = SUBTILIS_OP_INSTR_MOV;
+		break;
+	case SUBTILIS_EXP_REAL:
+	case SUBTILIS_EXP_STRING:
+	default:
+		subtilis_error_set_not_supported(err, tbuf, p->l->stream->name,
+						 p->l->line);
+		goto cleanup;
+	}
+	op0.reg = loc;
+	op2.integer = 0;
+	subtilis_ir_section_add_instr_reg(p->current, instr, op0, e->exp.ir_op,
+					  op2, err);
+
+cleanup:
+	subtilis_exp_delete(e);
+}
+
+static void prv_assign_to_mem(subtilis_parser_t *p, subtilis_token_t *t,
+			      const char *tbuf, subtilis_ir_operand_t op1,
+			      size_t loc, subtilis_error_t *err)
+{
+	size_t reg;
+	subtilis_op_instr_type_t instr;
+	subtilis_ir_operand_t op2;
+	subtilis_exp_t *e = NULL;
+
+	e = prv_expression(p, t, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		return;
+
+	switch (e->type) {
+	case SUBTILIS_EXP_CONST_INTEGER:
+		reg = subtilis_ir_section_add_instr2(
+		    p->current, SUBTILIS_OP_INSTR_MOVI_I32, e->exp.ir_op, err);
+		if (err->type != SUBTILIS_ERROR_OK)
+			goto cleanup;
+		subtilis_exp_delete(e);
+		e = subtilis_exp_new_var(SUBTILIS_EXP_INTEGER, reg, err);
+		if (err->type != SUBTILIS_ERROR_OK)
+			goto cleanup;
+		instr = SUBTILIS_OP_INSTR_STOREO_I32;
+		break;
+	case SUBTILIS_EXP_CONST_REAL:
+		instr = SUBTILIS_OP_INSTR_STOREO_REAL;
+		break;
+	case SUBTILIS_EXP_CONST_STRING:
+		subtilis_error_set_not_supported(err, tbuf, p->l->stream->name,
+						 p->l->line);
+		goto cleanup;
+	case SUBTILIS_EXP_INTEGER:
+		instr = SUBTILIS_OP_INSTR_STOREO_I32;
+		break;
+	case SUBTILIS_EXP_REAL:
+		instr = SUBTILIS_OP_INSTR_STOREO_REAL;
+		break;
+	case SUBTILIS_EXP_STRING:
+		subtilis_error_set_not_supported(err, tbuf, p->l->stream->name,
+						 p->l->line);
+		goto cleanup;
+	}
+	op2.integer = loc;
+	subtilis_ir_section_add_instr_reg(p->current, instr, e->exp.ir_op, op1,
+					  op2, err);
+
+cleanup:
+	subtilis_exp_delete(e);
+}
+
 static void prv_assignment(subtilis_parser_t *p, subtilis_token_t *t,
 			   subtilis_error_t *err)
 {
 	const char *tbuf;
-	subtilis_exp_t *e = NULL;
 	subtilis_ir_operand_t op1;
-	subtilis_ir_operand_t op2;
-	subtilis_op_instr_type_t instr;
 	const subtilis_symbol_t *s;
-	size_t reg;
 
 	tbuf = subtilis_token_get_text(t);
 
@@ -597,46 +684,11 @@ static void prv_assignment(subtilis_parser_t *p, subtilis_token_t *t,
 		    err, tbuf, p->l->stream->name, p->l->line);
 		return;
 	}
-	e = prv_expression(p, t, err);
-	if (err->type != SUBTILIS_ERROR_OK)
-		return;
 
-	switch (e->type) {
-	case SUBTILIS_EXP_CONST_INTEGER:
-		reg = subtilis_ir_section_add_instr2(
-		    p->current, SUBTILIS_OP_INSTR_MOVI_I32, e->exp.ir_op, err);
-		if (err->type != SUBTILIS_ERROR_OK)
-			goto cleanup;
-		subtilis_exp_delete(e);
-		e = subtilis_exp_new_var(SUBTILIS_EXP_INTEGER, reg, err);
-		if (err->type != SUBTILIS_ERROR_OK)
-			goto cleanup;
-		instr = SUBTILIS_OP_INSTR_STOREO_I32;
-		break;
-	case SUBTILIS_EXP_CONST_REAL:
-		instr = SUBTILIS_OP_INSTR_STOREO_REAL;
-		break;
-	case SUBTILIS_EXP_CONST_STRING:
-		subtilis_error_set_not_supported(err, tbuf, p->l->stream->name,
-						 p->l->line);
-		goto cleanup;
-	case SUBTILIS_EXP_INTEGER:
-		instr = SUBTILIS_OP_INSTR_STOREO_I32;
-		break;
-	case SUBTILIS_EXP_REAL:
-		instr = SUBTILIS_OP_INSTR_STOREO_REAL;
-		break;
-	case SUBTILIS_EXP_STRING:
-		subtilis_error_set_not_supported(err, tbuf, p->l->stream->name,
-						 p->l->line);
-		goto cleanup;
-	}
-	op2.integer = s->loc;
-	subtilis_ir_section_add_instr_reg(p->current, instr, e->exp.ir_op, op1,
-					  op2, err);
-
-cleanup:
-	subtilis_exp_delete(e);
+	if (s->is_reg)
+		prv_assign_to_reg(p, t, tbuf, s->loc, err);
+	else
+		prv_assign_to_mem(p, t, tbuf, op1, s->loc, err);
 }
 
 static void prv_let(subtilis_parser_t *p, subtilis_token_t *t,
@@ -661,6 +713,10 @@ static void prv_parse_locals(subtilis_parser_t *p, subtilis_token_t *t,
 			     subtilis_error_t *err)
 {
 	const char *tbuf;
+	size_t reg_num;
+	subtilis_ir_operand_t op1;
+
+	op1.integer = 0;
 
 	subtilis_lexer_get(p->l, t, err);
 	if (err->type != SUBTILIS_ERROR_OK)
@@ -684,8 +740,13 @@ static void prv_parse_locals(subtilis_parser_t *p, subtilis_token_t *t,
 			return;
 		}
 
-		(void)subtilis_symbol_table_insert(p->local_st, tbuf,
-						   SUBTILIS_TYPE_INTEGER, err);
+		reg_num = subtilis_ir_section_add_instr2(
+		    p->current, SUBTILIS_OP_INSTR_MOVI_I32, op1, err);
+		if (err->type != SUBTILIS_ERROR_OK)
+			return;
+
+		(void)subtilis_symbol_table_insert_reg(
+		    p->local_st, tbuf, SUBTILIS_TYPE_INTEGER, reg_num, err);
 		if (err->type != SUBTILIS_ERROR_OK)
 			return;
 
@@ -1016,10 +1077,6 @@ static void prv_def(subtilis_parser_t *p, subtilis_token_t *t,
 	if (err->type != SUBTILIS_ERROR_OK)
 		goto on_error;
 
-	prv_parse_locals(p, t, err);
-	if (err->type != SUBTILIS_ERROR_OK)
-		goto on_error;
-
 	stype = subtilis_type_section_new(SUBTILIS_TYPE_VOID, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		goto on_error;
@@ -1031,6 +1088,10 @@ static void prv_def(subtilis_parser_t *p, subtilis_token_t *t,
 		subtilis_type_section_delete(stype);
 		goto on_error;
 	}
+
+	prv_parse_locals(p, t, err);
+	if (err->type != SUBTILIS_ERROR_OK)
+		goto on_error;
 
 	prv_compound(p, t, SUBTILIS_KEYWORD_ENDPROC, err);
 	if (err->type != SUBTILIS_ERROR_OK)

--- a/riscos_arm2.c
+++ b/riscos_arm2.c
@@ -86,6 +86,7 @@ const subtilis_ir_rule_raw_t riscos_arm2_rules[] = {
 	{"neqi32 *, *, *\n", subtilis_arm_gen_neqi32},
 	{"gtei32 *, *, *\n", subtilis_arm_gen_gtei32},
 	{"ltei32 *, *, *\n", subtilis_arm_gen_ltei32},
+	{"mov *, *", subtilis_arm_gen_mov},
 	{"movii32 *, *", subtilis_arm_gen_movii32},
 	{"addii32 *, *, *", subtilis_arm_gen_addii32},
 	{"mulii32 *, *, *", subtilis_arm_gen_mulii32},

--- a/riscos_arm2.c
+++ b/riscos_arm2.c
@@ -72,7 +72,7 @@ const subtilis_ir_rule_raw_t riscos_arm2_rules[] = {
 	{"jmpc *, label_1, *\n"
 	"label_1\n",
 		 subtilis_arm_gen_jmpc},
-	{"call *\n", subtilis_arm_gen_call},
+	{"call\n", subtilis_arm_gen_call},
 	{"ret\n", subtilis_arm_gen_ret},
 	{"gtii32 *, *, *\n", subtilis_arm_gen_gtii32},
 	{"ltii32 *, *, *\n", subtilis_arm_gen_ltii32},

--- a/symbol_table.h
+++ b/symbol_table.h
@@ -24,6 +24,7 @@ struct subtilis_symbol_t_ {
 	size_t loc;
 	subtilis_type_t t;
 	size_t size;
+	bool is_reg;
 };
 
 typedef struct subtilis_symbol_t_ subtilis_symbol_t;
@@ -40,6 +41,10 @@ void subtilis_symbol_table_delete(subtilis_symbol_table_t *st);
 const subtilis_symbol_t *
 subtilis_symbol_table_insert(subtilis_symbol_table_t *st, const char *key,
 			     subtilis_type_t id_type, subtilis_error_t *err);
+const subtilis_symbol_t *
+subtilis_symbol_table_insert_reg(subtilis_symbol_table_t *st, const char *key,
+				 subtilis_type_t id_type, size_t reg_num,
+				 subtilis_error_t *err);
 bool subtilis_symbol_table_remove(subtilis_symbol_table_t *st, const char *key);
 const subtilis_symbol_t *
 subtilis_symbol_table_lookup(subtilis_symbol_table_t *st, const char *key);

--- a/vm.c
+++ b/vm.c
@@ -160,6 +160,12 @@ static void prv_movii32(subitlis_vm_t *vm, subtilis_buffer_t *b,
 	vm->regs[ops[0].reg] = ops[1].integer;
 }
 
+static void prv_mov(subitlis_vm_t *vm, subtilis_buffer_t *b,
+		    subtilis_ir_operand_t *ops, subtilis_error_t *err)
+{
+	vm->regs[ops[0].reg] = vm->regs[ops[1].reg];
+}
+
 static void prv_storeoi32(subitlis_vm_t *vm, subtilis_buffer_t *b,
 			  subtilis_ir_operand_t *ops, subtilis_error_t *err)
 {
@@ -502,7 +508,7 @@ static subtilis_vm_op_fn op_execute_fns[] = {
 	NULL,                                /* SUBTILIS_OP_INSTR_STORE_REAL */
 	prv_movii32,                         /* SUBTILIS_OP_INSTR_MOVI_I32 */
 	NULL,                                /* SUBTILIS_OP_INSTR_MOV_REAL */
-	NULL,                                /* SUBTILIS_OP_INSTR_MOV */
+	prv_mov,                                /* SUBTILIS_OP_INSTR_MOV */
 	NULL,                                /* SUBTILIS_OP_INSTR_MOVFP */
 	prv_printi32,                        /* SUBTILIS_OP_INSTR_PRINT_I32 */
 	prv_rsubii32,                        /* SUBTILIS_OP_INSTR_RSUBI_I32 */


### PR DESCRIPTION
This PR changes the way local variables are handled so that they are stored in registers if possible.  It also updates the compilers used in travis and changes the IR OP for invoking procedures as a stepping stone to parameter support.