### PR TITLE
Support more than 4 parameters

### DIFF
--- a/examples/printadd
+++ b/examples/printadd
@@ -3,8 +3,8 @@ LOCAL i%
 LET i% = 1
 LET j% = 2
 
-PROCAdd(i%, j%, 10)
+PROCAdd(i%, j%, 10, 11, 12)
 
-DEF PROCAdd(a%, b%, c%)
-  PRINT a% + b% + c%
+DEF PROCAdd(a%, b%, c%, d%, e%)
+  PRINT a% + b% + c% + d% + e%
 ENDPROC

--- a/test_cases.c
+++ b/test_cases.c
@@ -234,11 +234,11 @@ const subtilis_test_case_t test_cases[] = {
 	  "LOCAL i%\n"
 	  "LET i% = 1\n"
 	  "LET j% = 2\n"
-	  "PROCAdd(i%, j%, 10)\n"
-	  "DEF PROCAdd(a%, b%, c%)\n"
-	  "PRINT a% + b% + c%\n"
+	  "PROCAdd(i%, j%, 10, 11, 12)\n"
+	  "DEF PROCAdd(a%, b%, c%, d%, e%)\n"
+	  "PRINT a% + b% + c% +d% + e%\n"
 	  "ENDPROC\n",
-	  "13\n"},
+	  "36\n"},
 };
 
 /* clang-format on */


### PR DESCRIPTION
This commit adds support for more than 4 parameters.  The extra
parameters are placed onto the stack and the register allocator
is seeded with some fake virtual registers whose spilt offsets
correspond to the stack offsets of the extra args.  This way
the register allocator takes care of restoring these arguments
to real registers when they're needed.

Signed-off-by: Mark Ryan <markusdryan@gmail.com>