### PR TITLE
Add link to the Subtilis documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,5 @@ constructs to the lanuage.  To start with there will probably only be two target
 OSes, RISCOS 3 and RISCOS 4, and one CPU family, ARM 2 or greater.  Ultimately
 the goal is to create a backend for the native ARM processor mode of PiTubeDirect,
 but this is a long way off.
+
+Please see the Subtilis [documentation](https://github.com/markdryan/subtilis/blob/master/docs/Subtilis.md) for more details

--- a/docs/Subtilis.md
+++ b/docs/Subtilis.md
@@ -189,7 +189,7 @@ ENDPROC
 ```
 
 will not.  This is done on purpose to prevent users from accidentally declaring a
-global variable when the really want a local variable.  You almost always want a
+global variable when they really want a local variable.  You almost always want a
 local variable in Subtilis as local variables are assigned to registers where as
 global variables are not.  Operations involving local variables are consequently,
 much faster than the equivalent operations involving global variables.  One side
@@ -379,7 +379,7 @@ Here's a list of other language features that are currently not implemented but 
 * POINT TO
 
 There are also some enhancements that will need to be added to the language to make it
-more palatable to the modern programmers.
+more palatable to the modern programmer.
 
 * Lower case keywords
 * Structures


### PR DESCRIPTION
Add a link in the README file to the new Subtilis documentation.

Signed-off-by: Mark Ryan <markusdryan@gmail.com>