### PR TITLE
FPA has 8 registers not 6

### DIFF
--- a/arm_core.h
+++ b/arm_core.h
@@ -26,13 +26,13 @@
 /*
  * Two register namespaces overlap for each register type, int or real.
  * For integers register numbers < 16 are fixed and will not be altered
- * by the register allocator.  FPA register numbers < 6 are fixed.
+ * by the register allocator.  FPA register numbers < 8 are fixed.
  * All other register numbers are floating and will need to be allocated
  * to a fixed register during register allocation.
  */
 
 #define SUBTILIS_ARM_INT_VIRT_REG_START 16
-#define SUBTILIS_ARM_FPA_VIRT_REG_START 6
+#define SUBTILIS_ARM_FPA_VIRT_REG_START 8
 
 typedef size_t subtilis_arm_reg_t;
 

--- a/arm_gen.c
+++ b/arm_gen.c
@@ -19,6 +19,7 @@
 #include "arm_gen.h"
 
 #include "arm_core.h"
+#include "arm_reg_alloc.h"
 
 static void prv_data_simple(subtilis_ir_section_t *s, size_t start,
 			    void *user_data, subtilis_arm_instr_type_t itype,
@@ -828,7 +829,8 @@ void subtilis_arm_gen_call_gen(subtilis_ir_section_t *s, size_t start,
 
 	if (s->freg_counter > 0) {
 		save_real_start = real_args > 4 ? 4 : real_args;
-		for (i = save_real_start; i < 6; i++) {
+		for (i = save_real_start; i < SUBTILIS_ARM_REG_MAX_FPA_REGS;
+		     i++) {
 			fpa_reg = i;
 			subtilis_fpa_push_reg(arm_s, SUBTILIS_ARM_CCODE_NV,
 					      fpa_reg, err);
@@ -853,7 +855,8 @@ void subtilis_arm_gen_call_gen(subtilis_ir_section_t *s, size_t start,
 	call_site = arm_s->last_op;
 
 	if (s->freg_counter > 0) {
-		for (i = 5; i >= save_real_start; i--) {
+		for (i = SUBTILIS_ARM_REG_MAX_FPA_REGS - 1;
+		     i >= save_real_start; i--) {
 			fpa_reg = i;
 			subtilis_fpa_pop_reg(arm_s, SUBTILIS_ARM_CCODE_NV,
 					     fpa_reg, err);

--- a/arm_reg_alloc.c
+++ b/arm_reg_alloc.c
@@ -2280,9 +2280,9 @@ static void prv_update_arg_offsets(subtilis_arm_section_t *arm_s,
 		if (1 << i & int_regs_used)
 			bytes_saved += sizeof(int32_t);
 
-	/* TODO: 6 here is FPA specific */
+	/* TODO: SUBTILIS_ARM_REG_MAX_FPA_REGS here is FPA specific */
 
-	for (i = 0; i < 6; i++)
+	for (i = 0; i < SUBTILIS_ARM_REG_MAX_FPA_REGS; i++)
 		if (1 << i & real_regs_used)
 			bytes_saved += sizeof(double);
 
@@ -2347,7 +2347,8 @@ static void prv_compute_regs_used(subtilis_arm_section_t *arm_s,
 
 	real_regs_saved = call_site->real_args;
 	if (real_regs_saved > SUBTILIS_ARM_REG_MIN_FPA_REGS)
-		real_regs_saved = 2;
+		real_regs_saved = SUBTILIS_ARM_REG_MAX_FPA_REGS -
+				  SUBTILIS_ARM_REG_MIN_FPA_REGS;
 	else
 		real_regs_saved =
 		    SUBTILIS_ARM_REG_MAX_FPA_REGS - real_regs_saved;

--- a/arm_reg_alloc.h
+++ b/arm_reg_alloc.h
@@ -24,7 +24,7 @@
 #define SUBTILIS_ARM_REG_MAX_INT_REGS 11
 
 #define SUBTILIS_ARM_REG_MIN_FPA_REGS 4
-#define SUBTILIS_ARM_REG_MAX_FPA_REGS 6
+#define SUBTILIS_ARM_REG_MAX_FPA_REGS 8
 
 struct subtilis_dist_data_t_ {
 	size_t reg_num;

--- a/arm_vm.h
+++ b/arm_vm.h
@@ -32,7 +32,7 @@ typedef struct subtilis_arm_vm_freg_t_ subtilis_arm_vm_freg_t;
 
 struct subtilis_arm_vm_t_ {
 	int32_t regs[16];
-	subtilis_arm_vm_freg_t fregs[6];
+	subtilis_arm_vm_freg_t fregs[8];
 	uint8_t *memory;
 	size_t mem_size;
 	size_t code_size;


### PR DESCRIPTION
Should have read the documentation a little better.  This commit
modifies the register allocator to use all 8 registers.  It also
fixes parts of the code that had hard coded constants for the
number of FPA registers.

Signed-off-by: Mark Ryan <markusdryan@gmail.com>