### PR TITLE
Implement constant pooling

### DIFF
--- a/test_cases.c
+++ b/test_cases.c
@@ -350,14 +350,6 @@ const subtilis_test_case_t test_cases[] = {
 	  "PRINT a = c\n"
 	  "PRINT a <> b\n"
 	  "PRINT a <> c\n"
-	  "PROCRelational\n"
-	  "DEF PROCRelational\n"
-	  "LOCAL a\n"
-	  "LOCAL b\n"
-	  "LOCAL c\n"
-	  "LET a = 3.14\n"
-	  "LET b = 17.6666\n"
-	  "LET c = 3.14\n"
 	  "PRINT a < 17.6666\n"
 	  "PRINT a > 17.6666\n"
 	  "PRINT a = 17.6666\n"
@@ -371,12 +363,6 @@ const subtilis_test_case_t test_cases[] = {
 	  "PRINT 3.14 <> b\n"
 	  "PRINT 3.14 <> c\n"
 	  "PRINT a <> 2.0\n"
-	  "ENDPROC\n"
-	  "PROCLogical\n"
-	  "\n"
-	  "DEF PROCLogical\n"
-	  "LOCAL a\n"
-	  "LET a = 3.14\n"
 	  "PRINT a OR b\n"
 	  "PRINT a AND b\n"
 	  "PRINT a EOR b\n"
@@ -384,8 +370,7 @@ const subtilis_test_case_t test_cases[] = {
 	  "PRINT a OR 17.6666\n"
 	  "PRINT a AND 17.6666\n"
 	  "PRINT a EOR 17.6666\n"
-	  "PRINT NOT 3.14\n"
-	  "ENDPROC\n",
+	  "PRINT NOT 3.14\n",
 	  "-1\n0\n0\n-1\n-1\n0\n-1\n0\n0\n-1\n-1\n0\n-1\n0\n0\n"
 	  "-1\n-1\n0\n-1\n19\n1\n18\n-4\n19\n1\n18\n-4\n"},
 	{ "fpa_if",


### PR DESCRIPTION
Finally, we can have functions > 1024 bytes.  Pools are inserted
in the ARM code when needed and skipped with a branch instruction.

The support procedures in one of the test cases, fpa_logical, have
been removed as they are no longer needed.  Previously, this test
case would not compile as a single procedure due to the presence of
floating point constants and the lack of constant pooling.  Now we
have constant pooling, we no longer need those extra procedures.
Removing them tests our pooling code.

Signed-off-by: Mark Ryan <markusdryan@gmail.com>