### PR TITLE
Fix a small bug in the docs

### DIFF
--- a/docs/Subtilis.md
+++ b/docs/Subtilis.md
@@ -311,7 +311,7 @@ Subtilis introduces the ':=' operator which creates a new local variable and
 assigns a value to that variable.
 
 ```
-x% = 1
+x% := 1
 ```
 
 is equivalent to writing


### PR DESCRIPTION
Missing a : in the := documentation.

Signed-off-by: Mark Ryan <markusdryan@gmail.com>