### PR TITLE
Register Allocation fixes

### DIFF
--- a/arch/arm32/arm_fpa_dist.c
+++ b/arch/arm32/arm_fpa_dist.c
@@ -304,3 +304,120 @@ void subtilis_init_fpa_dist_walker(subtlis_arm_walker_t *walker,
 	walker->fpa_ldrc_fn = prv_dist_fpa_ldrc_instr;
 	walker->fpa_cptran_fn = prv_dist_fpa_cptran_instr;
 }
+
+static void prv_used_fpa_data_dyadic_instr(void *user_data,
+					   subtilis_arm_op_t *op,
+					   subtilis_arm_instr_type_t type,
+					   subtilis_fpa_data_instr_t *instr,
+					   subtilis_error_t *err)
+{
+	subtilis_dist_data_t *ud = user_data;
+
+	if (instr->dest == ud->reg_num) {
+		ud->last_used = -1;
+		subtilis_error_set_walker_failed(err);
+		return;
+	}
+
+	ud->last_used++;
+}
+
+static void prv_used_fpa_data_monadic_instr(void *user_data,
+					    subtilis_arm_op_t *op,
+					    subtilis_arm_instr_type_t type,
+					    subtilis_fpa_data_instr_t *instr,
+					    subtilis_error_t *err)
+{
+	subtilis_dist_data_t *ud = user_data;
+
+	if (instr->dest == ud->reg_num) {
+		ud->last_used = -1;
+		subtilis_error_set_walker_failed(err);
+		return;
+	}
+
+	ud->last_used++;
+}
+
+static void prv_used_fpa_stran_instr(void *user_data, subtilis_arm_op_t *op,
+				     subtilis_arm_instr_type_t type,
+				     subtilis_fpa_stran_instr_t *instr,
+				     subtilis_error_t *err)
+{
+	subtilis_dist_data_t *ud = user_data;
+
+	/*
+	 * The function calling code can generate LDFNV and STFNV when
+	 * preserving fpa registers.  These instructions should be
+	 * ignored for the purposes of register allocation.
+	 */
+
+	if (instr->ccode != SUBTILIS_ARM_CCODE_NV) {
+		if (type != SUBTILIS_FPA_INSTR_STF) {
+			if (instr->dest == ud->reg_num) {
+				ud->last_used = -1;
+				subtilis_error_set_walker_failed(err);
+				return;
+			}
+		}
+	}
+
+	ud->last_used++;
+}
+
+static void prv_used_fpa_tran_instr(void *user_data, subtilis_arm_op_t *op,
+				    subtilis_arm_instr_type_t type,
+				    subtilis_fpa_tran_instr_t *instr,
+				    subtilis_error_t *err)
+{
+	subtilis_dist_data_t *ud = user_data;
+
+	if (type == SUBTILIS_FPA_INSTR_FLT) {
+		if (instr->dest == ud->reg_num) {
+			ud->last_used = -1;
+			subtilis_error_set_walker_failed(err);
+			return;
+		}
+	}
+
+	ud->last_used++;
+}
+
+static void prv_used_fpa_cmp_instr(void *user_data, subtilis_arm_op_t *op,
+				   subtilis_arm_instr_type_t type,
+				   subtilis_fpa_cmp_instr_t *instr,
+				   subtilis_error_t *err)
+{
+	subtilis_dist_data_t *ud = user_data;
+
+	if (!instr->immediate && instr->op2.reg == ud->reg_num) {
+		subtilis_error_set_walker_failed(err);
+		return;
+	}
+
+	ud->last_used++;
+}
+
+void subtilis_init_fpa_used_walker(subtlis_arm_walker_t *walker,
+				   void *user_data)
+{
+	walker->user_data = user_data;
+	walker->label_fn = prv_dist_label;
+	walker->data_fn = prv_dist_data_instr;
+	walker->mul_fn = prv_dist_mul_instr;
+	walker->cmp_fn = prv_dist_cmp_instr;
+	walker->mov_fn = prv_dist_mov_instr;
+	walker->stran_fn = prv_dist_stran_instr;
+	walker->mtran_fn = prv_dist_mtran_instr;
+	walker->br_fn = prv_dist_br_instr;
+	walker->swi_fn = prv_dist_swi_instr;
+	walker->ldrc_fn = prv_dist_ldrc_instr;
+	walker->cmov_fn = prv_dist_cmov_instr;
+	walker->fpa_data_monadic_fn = prv_used_fpa_data_monadic_instr;
+	walker->fpa_data_dyadic_fn = prv_used_fpa_data_dyadic_instr;
+	walker->fpa_stran_fn = prv_used_fpa_stran_instr;
+	walker->fpa_tran_fn = prv_used_fpa_tran_instr;
+	walker->fpa_cmp_fn = prv_used_fpa_cmp_instr;
+	walker->fpa_ldrc_fn = prv_dist_fpa_ldrc_instr;
+	walker->fpa_cptran_fn = prv_dist_fpa_cptran_instr;
+}

--- a/arch/arm32/arm_fpa_dist.h
+++ b/arch/arm32/arm_fpa_dist.h
@@ -21,5 +21,7 @@
 
 void subtilis_init_fpa_dist_walker(subtlis_arm_walker_t *walker,
 				   void *user_data);
+void subtilis_init_fpa_used_walker(subtlis_arm_walker_t *walker,
+				   void *user_data);
 
 #endif

--- a/arch/arm32/arm_int_dist.c
+++ b/arch/arm32/arm_int_dist.c
@@ -37,7 +37,6 @@ static void prv_dist_handle_op2(subtilis_dist_data_t *ud,
 			return;
 		}
 	}
-	ud->last_used++;
 }
 
 static void prv_dist_mov_instr(void *user_data, subtilis_arm_op_t *op,
@@ -56,6 +55,8 @@ static void prv_dist_mov_instr(void *user_data, subtilis_arm_op_t *op,
 		subtilis_error_set_walker_failed(err);
 		return;
 	}
+
+	ud->last_used++;
 }
 
 static void prv_dist_data_instr(void *user_data, subtilis_arm_op_t *op,
@@ -79,6 +80,8 @@ static void prv_dist_data_instr(void *user_data, subtilis_arm_op_t *op,
 		subtilis_error_set_walker_failed(err);
 		return;
 	}
+
+	ud->last_used++;
 }
 
 static void prv_dist_mul_instr(void *user_data, subtilis_arm_op_t *op,
@@ -135,6 +138,8 @@ static void prv_dist_stran_instr(void *user_data, subtilis_arm_op_t *op,
 			return;
 		}
 	}
+
+	ud->last_used++;
 }
 
 static void prv_dist_mtran_instr(void *user_data, subtilis_arm_op_t *op,
@@ -255,6 +260,8 @@ static void prv_dist_cmp_instr(void *user_data, subtilis_arm_op_t *op,
 	}
 
 	prv_dist_handle_op2(ud, &instr->op2, err);
+
+	ud->last_used++;
 }
 
 static void prv_dist_label(void *user_data, subtilis_arm_op_t *op, size_t label,

--- a/arch/arm32/arm_int_dist.c
+++ b/arch/arm32/arm_int_dist.c
@@ -393,3 +393,168 @@ void subtilis_init_int_dist_walker(subtlis_arm_walker_t *walker,
 	walker->fpa_ldrc_fn = prv_dist_fpa_ldrc_instr;
 	walker->fpa_cptran_fn = prv_dist_fpa_cptran_instr;
 }
+
+static void prv_used_mov_instr(void *user_data, subtilis_arm_op_t *op,
+			       subtilis_arm_instr_type_t type,
+			       subtilis_arm_data_instr_t *instr,
+			       subtilis_error_t *err)
+{
+	subtilis_dist_data_t *ud = user_data;
+
+	if (instr->dest == ud->reg_num) {
+		ud->last_used = -1;
+		subtilis_error_set_walker_failed(err);
+		return;
+	}
+
+	ud->last_used++;
+}
+
+static void prv_used_data_instr(void *user_data, subtilis_arm_op_t *op,
+				subtilis_arm_instr_type_t type,
+				subtilis_arm_data_instr_t *instr,
+				subtilis_error_t *err)
+{
+	subtilis_dist_data_t *ud = user_data;
+
+	if (instr->dest == ud->reg_num) {
+		ud->last_used = -1;
+		subtilis_error_set_walker_failed(err);
+		return;
+	}
+
+	ud->last_used++;
+}
+
+static void prv_used_mul_instr(void *user_data, subtilis_arm_op_t *op,
+			       subtilis_arm_instr_type_t type,
+			       subtilis_arm_mul_instr_t *instr,
+			       subtilis_error_t *err)
+{
+	subtilis_dist_data_t *ud = user_data;
+
+	if (instr->dest == ud->reg_num) {
+		ud->last_used = -1;
+		subtilis_error_set_walker_failed(err);
+		return;
+	}
+
+	ud->last_used++;
+}
+
+static void prv_used_stran_instr(void *user_data, subtilis_arm_op_t *op,
+				 subtilis_arm_instr_type_t type,
+				 subtilis_arm_stran_instr_t *instr,
+				 subtilis_error_t *err)
+{
+	subtilis_dist_data_t *ud = user_data;
+
+	/*
+	 * TODO: register allocator does not correctly cope with
+	 * pre-index addressing or writeback.
+	 */
+
+	if (type == SUBTILIS_ARM_INSTR_LDR) {
+		if (instr->dest == ud->reg_num) {
+			ud->last_used = -1;
+			subtilis_error_set_walker_failed(err);
+			return;
+		}
+	}
+
+	ud->last_used++;
+}
+
+static void prv_used_swi_instr(void *user_data, subtilis_arm_op_t *op,
+			       subtilis_arm_instr_type_t type,
+			       subtilis_arm_swi_instr_t *instr,
+			       subtilis_error_t *err)
+{
+	subtilis_dist_data_t *ud = user_data;
+
+	if ((ud->reg_num < 10) && (1 << ud->reg_num) & instr->reg_write_mask) {
+		ud->last_used = -1;
+		subtilis_error_set_walker_failed(err);
+		return;
+	}
+
+	ud->last_used++;
+}
+
+static void prv_used_cmov_instr(void *user_data, subtilis_arm_op_t *op,
+				subtilis_arm_instr_type_t type,
+				subtilis_arm_cmov_instr_t *instr,
+				subtilis_error_t *err)
+{
+	subtilis_dist_data_t *ud = user_data;
+
+	if (instr->dest == ud->reg_num) {
+		ud->last_used = -1;
+		subtilis_error_set_walker_failed(err);
+		return;
+	}
+
+	ud->last_used++;
+}
+
+static void prv_used_cmp_instr(void *user_data, subtilis_arm_op_t *op,
+			       subtilis_arm_instr_type_t type,
+			       subtilis_arm_data_instr_t *instr,
+			       subtilis_error_t *err)
+{
+	subtilis_dist_data_t *ud = user_data;
+
+	ud->last_used++;
+}
+
+static void prv_used_fpa_stran_instr(void *user_data, subtilis_arm_op_t *op,
+				     subtilis_arm_instr_type_t type,
+				     subtilis_fpa_stran_instr_t *instr,
+				     subtilis_error_t *err)
+{
+	subtilis_dist_data_t *ud = user_data;
+
+	ud->last_used++;
+}
+
+static void prv_used_fpa_tran_instr(void *user_data, subtilis_arm_op_t *op,
+				    subtilis_arm_instr_type_t type,
+				    subtilis_fpa_tran_instr_t *instr,
+				    subtilis_error_t *err)
+{
+	subtilis_dist_data_t *ud = user_data;
+
+	if (type != SUBTILIS_FPA_INSTR_FLT) {
+		if (instr->dest == ud->reg_num) {
+			ud->last_used = -1;
+			subtilis_error_set_walker_failed(err);
+			return;
+		}
+	}
+
+	ud->last_used++;
+}
+
+void subtilis_init_int_used_walker(subtlis_arm_walker_t *walker,
+				   void *user_data)
+{
+	walker->user_data = user_data;
+	walker->label_fn = prv_dist_label;
+	walker->data_fn = prv_used_data_instr;
+	walker->mul_fn = prv_used_mul_instr;
+	walker->cmp_fn = prv_used_cmp_instr;
+	walker->mov_fn = prv_used_mov_instr;
+	walker->stran_fn = prv_used_stran_instr;
+	walker->mtran_fn = prv_dist_mtran_instr;
+	walker->br_fn = prv_dist_br_instr;
+	walker->swi_fn = prv_used_swi_instr;
+	walker->ldrc_fn = prv_dist_ldrc_instr;
+	walker->cmov_fn = prv_used_cmov_instr;
+	walker->fpa_data_monadic_fn = prv_dist_fpa_data_monadic_instr;
+	walker->fpa_data_dyadic_fn = prv_dist_fpa_data_dyadic_instr;
+	walker->fpa_stran_fn = prv_used_fpa_stran_instr;
+	walker->fpa_tran_fn = prv_used_fpa_tran_instr;
+	walker->fpa_cmp_fn = prv_dist_fpa_cmp_instr;
+	walker->fpa_ldrc_fn = prv_dist_fpa_ldrc_instr;
+	walker->fpa_cptran_fn = prv_dist_fpa_cptran_instr;
+}

--- a/arch/arm32/arm_int_dist.h
+++ b/arch/arm32/arm_int_dist.h
@@ -21,5 +21,7 @@
 
 void subtilis_init_int_dist_walker(subtlis_arm_walker_t *walker,
 				   void *user_data);
+void subtilis_init_int_used_walker(subtlis_arm_walker_t *walker,
+				   void *user_data);
 
 #endif

--- a/frontend/array_type.c
+++ b/frontend/array_type.c
@@ -1174,7 +1174,6 @@ void subtilis_array_type_deref_els(subtilis_parser_t *p, size_t data_reg,
 	subtilis_ir_operand_t op2;
 	subtilis_ir_operand_t data_end;
 	subtilis_ir_operand_t counter;
-	subtilis_ir_operand_t counter2;
 	subtilis_ir_operand_t conde;
 	subtilis_ir_operand_t start;
 	subtilis_ir_operand_t end;
@@ -1208,13 +1207,8 @@ void subtilis_array_type_deref_els(subtilis_parser_t *p, size_t data_reg,
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
 
-	counter2.reg = subtilis_ir_section_add_instr(
-	    p->current, SUBTILIS_OP_INSTR_ADDI_I32, counter, op2, err);
-	if (err->type != SUBTILIS_ERROR_OK)
-		return;
-
-	subtilis_ir_section_add_instr_no_reg2(p->current, SUBTILIS_OP_INSTR_MOV,
-					      counter, counter2, err);
+	subtilis_ir_section_add_instr_reg(
+	    p->current, SUBTILIS_OP_INSTR_ADDI_I32, counter, counter, op2, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
 

--- a/frontend/builtins_ir.c
+++ b/frontend/builtins_ir.c
@@ -711,13 +711,8 @@ void subtilis_builtins_ir_fp_to_str(subtilis_parser_t *p,
 		goto cleanup;
 
 	op1.integer = 1;
-	op0.reg = subtilis_ir_section_add_instr(
-	    current, SUBTILIS_OP_INSTR_ADDI_I32, arg_buf, op1, err);
-	if (err->type != SUBTILIS_ERROR_OK)
-		goto cleanup;
-
-	subtilis_ir_section_add_instr_no_reg2(current, SUBTILIS_OP_INSTR_MOV,
-					      arg_buf, op0, err);
+	subtilis_ir_section_add_instr_reg(current, SUBTILIS_OP_INSTR_ADDI_I32,
+					  arg_buf, arg_buf, op1, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		goto cleanup;
 
@@ -968,13 +963,8 @@ void subtilis_builtins_ir_dec_to_str(subtilis_parser_t *p,
 		goto cleanup;
 
 	op1.integer = 1;
-	op0.reg = subtilis_ir_section_add_instr(
-	    current, SUBTILIS_OP_INSTR_ADDI_I32, arg_buf, op1, err);
-	if (err->type != SUBTILIS_ERROR_OK)
-		goto cleanup;
-
-	subtilis_ir_section_add_instr_no_reg2(current, SUBTILIS_OP_INSTR_MOV,
-					      arg_buf, op0, err);
+	subtilis_ir_section_add_instr_reg(current, SUBTILIS_OP_INSTR_ADDI_I32,
+					  arg_buf, arg_buf, op1, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		goto cleanup;
 
@@ -1026,13 +1016,8 @@ void subtilis_builtins_ir_dec_to_str(subtilis_parser_t *p,
 	val = NULL;
 
 	op1.integer = 1;
-	op0.reg = subtilis_ir_section_add_instr(
-	    current, SUBTILIS_OP_INSTR_ADDI_I32, arg_buf, op1, err);
-	if (err->type != SUBTILIS_ERROR_OK)
-		goto cleanup;
-
-	subtilis_ir_section_add_instr_no_reg2(current, SUBTILIS_OP_INSTR_MOV,
-					      arg_buf, op0, err);
+	subtilis_ir_section_add_instr_reg(current, SUBTILIS_OP_INSTR_ADDI_I32,
+					  arg_buf, arg_buf, op1, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		goto cleanup;
 
@@ -1074,13 +1059,8 @@ void subtilis_builtins_ir_dec_to_str(subtilis_parser_t *p,
 	 */
 
 	op1.integer = 1;
-	op0.reg = subtilis_ir_section_add_instr(
-	    current, SUBTILIS_OP_INSTR_SUBI_I32, arg_buf, op1, err);
-	if (err->type != SUBTILIS_ERROR_OK)
-		goto cleanup;
-
-	subtilis_ir_section_add_instr_no_reg2(current, SUBTILIS_OP_INSTR_MOV,
-					      arg_buf, op0, err);
+	subtilis_ir_section_add_instr_reg(current, SUBTILIS_OP_INSTR_SUBI_I32,
+					  arg_buf, arg_buf, op1, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		goto cleanup;
 
@@ -1120,13 +1100,8 @@ void subtilis_builtins_ir_dec_to_str(subtilis_parser_t *p,
 		goto cleanup;
 
 	op1.integer = 1;
-	op0.reg = subtilis_ir_section_add_instr(
-	    current, SUBTILIS_OP_INSTR_SUBI_I32, arg_buf, op1, err);
-	if (err->type != SUBTILIS_ERROR_OK)
-		goto cleanup;
-
-	subtilis_ir_section_add_instr_no_reg2(current, SUBTILIS_OP_INSTR_MOV,
-					      arg_buf, op0, err);
+	subtilis_ir_section_add_instr_reg(current, SUBTILIS_OP_INSTR_SUBI_I32,
+					  arg_buf, arg_buf, op1, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		goto cleanup;
 
@@ -1135,13 +1110,9 @@ void subtilis_builtins_ir_dec_to_str(subtilis_parser_t *p,
 	if (err->type != SUBTILIS_ERROR_OK)
 		goto cleanup;
 
-	op0.reg = subtilis_ir_section_add_instr(
-	    current, SUBTILIS_OP_INSTR_ADDI_I32, reverse_start, op1, err);
-	if (err->type != SUBTILIS_ERROR_OK)
-		goto cleanup;
-
-	subtilis_ir_section_add_instr_no_reg2(current, SUBTILIS_OP_INSTR_MOV,
-					      reverse_start, op0, err);
+	subtilis_ir_section_add_instr_reg(current, SUBTILIS_OP_INSTR_ADDI_I32,
+					  reverse_start, reverse_start, op1,
+					  err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		goto cleanup;
 
@@ -1293,13 +1264,8 @@ void subtilis_builtins_ir_hex_to_str(subtilis_parser_t *p,
 		goto cleanup;
 
 	op1.integer = 1;
-	op0.reg = subtilis_ir_section_add_instr(
-	    current, SUBTILIS_OP_INSTR_ADDI_I32, arg_buf, op1, err);
-	if (err->type != SUBTILIS_ERROR_OK)
-		goto cleanup;
-
-	subtilis_ir_section_add_instr_no_reg2(current, SUBTILIS_OP_INSTR_MOV,
-					      arg_buf, op0, err);
+	subtilis_ir_section_add_instr_reg(current, SUBTILIS_OP_INSTR_ADDI_I32,
+					  arg_buf, arg_buf, op1, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		goto cleanup;
 

--- a/frontend/parser_array.c
+++ b/frontend/parser_array.c
@@ -451,7 +451,6 @@ static void prv_read_string_table(subtilis_parser_t *p, size_t array_base,
 	subtilis_ir_operand_t table_end;
 	subtilis_ir_operand_t op1;
 	subtilis_ir_operand_t size;
-	subtilis_ir_operand_t tmp;
 	subtilis_ir_operand_t cond;
 	subtilis_ir_operand_t skip;
 	subtilis_ir_operand_t lca_offset;
@@ -520,24 +519,16 @@ static void prv_read_string_table(subtilis_parser_t *p, size_t array_base,
 		return;
 
 	op1.integer = (int32_t)element_size;
-	tmp.reg = subtilis_ir_section_add_instr(
-	    p->current, SUBTILIS_OP_INSTR_ADDI_I32, array_ptr, op1, err);
-	if (err->type != SUBTILIS_ERROR_OK)
-		return;
-
-	subtilis_ir_section_add_instr_no_reg2(p->current, SUBTILIS_OP_INSTR_MOV,
-					      array_ptr, tmp, err);
+	subtilis_ir_section_add_instr_reg(p->current,
+					  SUBTILIS_OP_INSTR_ADDI_I32, array_ptr,
+					  array_ptr, op1, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
 
 	op1.integer = sizeof(int32_t) * 2;
-	tmp.reg = subtilis_ir_section_add_instr(
-	    p->current, SUBTILIS_OP_INSTR_ADDI_I32, table_ptr, op1, err);
-	if (err->type != SUBTILIS_ERROR_OK)
-		return;
-
-	subtilis_ir_section_add_instr_no_reg2(p->current, SUBTILIS_OP_INSTR_MOV,
-					      table_ptr, tmp, err);
+	subtilis_ir_section_add_instr_reg(p->current,
+					  SUBTILIS_OP_INSTR_ADDI_I32, table_ptr,
+					  table_ptr, op1, err);
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
 

--- a/frontend/reference_type.c
+++ b/frontend/reference_type.c
@@ -625,24 +625,10 @@ void subtilis_reference_inc_cleanup_stack(subtilis_parser_t *p,
 	if (err->type != SUBTILIS_ERROR_OK)
 		return;
 
-	/*
-	 * TODO: The part of the register allocator that preserves
-	 * live registers between basic blocks can't handle the case
-	 * when an instruction uses the same register for both source
-	 * and destination.  Ultimately, all that code is going to
-	 * dissapear when we have a global register allocator, so for
-	 * now we're just going to live with it.
-	 */
-
 	op2.integer = 1;
 	dest.reg = p->current->cleanup_stack;
-	op2.reg = subtilis_ir_section_add_instr(
-	    p->current, SUBTILIS_OP_INSTR_ADDI_I32, dest, op2, err);
-	if (err->type != SUBTILIS_ERROR_OK)
-		return;
-
-	subtilis_ir_section_add_instr_no_reg2(p->current, SUBTILIS_OP_INSTR_MOV,
-					      dest, op2, err);
+	subtilis_ir_section_add_instr_reg(
+	    p->current, SUBTILIS_OP_INSTR_ADDI_I32, dest, dest, op2, err);
 }
 
 size_t subtilis_reference_type_raw_alloc(subtilis_parser_t *p, size_t size_reg,


### PR DESCRIPTION
Fix two more long standing bugs in the register allocator.  One of the bug fixes allows us to simplify the IR code we generate and so this PR does this as well.