### PR TITLE
Update documentation again and disable debug output

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ BASIC programs so that they can be compiled with Subtilis.
 
 Please see the Subtilis [documentation](https://github.com/markdryan/subtilis/blob/master/docs/Subtilis.md) for more details.
 
-Subtilis is still very much in its infancy and is not ready to be used by people
+Subtilis is still very much in its infancy and is not recommended for use by anyone
 other than it's author.  Nevertheless, if you want to play around with it, please visit
 the [GettingStarted](https://github.com/markdryan/subtilis/blob/master/docs/GettingStarted.md) page.

--- a/compiler.c
+++ b/compiler.c
@@ -73,7 +73,7 @@ int main(int argc, char *argv[])
 	if (err.type != SUBTILIS_ERROR_OK)
 		goto cleanup;
 
-	subtilis_ir_prog_dump(p->prog);
+	//	subtilis_ir_prog_dump(p->prog);
 
 	pool = subtilis_arm_op_pool_new(&err);
 	if (err.type != SUBTILIS_ERROR_OK)
@@ -85,8 +85,8 @@ int main(int argc, char *argv[])
 	if (err.type != SUBTILIS_ERROR_OK)
 		goto cleanup;
 
-	printf("\n\n");
-	subtilis_arm_prog_dump(arm_p);
+	//	printf("\n\n");
+	//	subtilis_arm_prog_dump(arm_p);
 
 	subtilis_arm_encode(arm_p, "RunImage", prv_set_prog_size, &err);
 	if (err.type != SUBTILIS_ERROR_OK)

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -2,7 +2,7 @@
 
 ## Building Subtilis
 
-Subtilis can be run on modern computers as a cross compiler or directly on a RiscOS 3 or RiscOS4 machine such as a RiscPC.  To build Subtilis for Linux or MacOS simply type.
+Subtilis can be built and run on modern computers as a cross compiler or directly on a RiscOS 3 or RiscOS 4 machine such as a RiscPC.  To build Subtilis for Linux or MacOS you'll need a C99 compiler and a make tool.  Once you have these installed simply type
 
 ```
 git clone git@github.com:markdryan/subtilis.git


### PR DESCRIPTION
The compiler longer prints out the dissassembly listings when compiling.