### PR TITLE
Makefiles: Change optimisation options for RiscOS

### DIFF
--- a/ROMakefile
+++ b/ROMakefile
@@ -5,7 +5,7 @@ COMPONENT = basicc
 OBJS = compiler
 LIBS = backends.riscos.o.riscos arch.arm32.o.arm32 frontend.o.frontend common.o.common
 
-CFLAGS ?= -Wxla
+CFLAGS ?= -Wxla -Otime
 
 INSTDIR ?= <Obey$Dir>
 

--- a/arch/arm32/ROMakefile
+++ b/arch/arm32/ROMakefile
@@ -4,7 +4,7 @@ COMPONENT = arm32
 
 OBJS = arm2_div arm_core arm_dump arm_encode arm_fpa_dist arm_gen arm_keywords arm_int_dist arm_link arm_peephole arm_reg_alloc arm_sub_section arm_vm arm_walker fpa fpa_gen arm_mem arm_heap assembler arm_expression
 
-CFLAGS ?= -Wxla
+CFLAGS ?= -Wxla -Otime
 
 INSTDIR ?= <Obey$Dir>
 

--- a/backends/riscos/ROMakefile
+++ b/backends/riscos/ROMakefile
@@ -4,7 +4,7 @@ COMPONENT = riscos
 
 OBJS = riscos_arm riscos_arm2 riscos_swi
 
-CFLAGS ?= -Wxla
+CFLAGS ?= -Wxla -Otime
 
 INSTDIR ?= <Obey$Dir>
 

--- a/common/ROMakefile
+++ b/common/ROMakefile
@@ -4,7 +4,7 @@ COMPONENT = common
 
 OBJS = lexer error stream utils buffer ir bitset builtins constant_pool string_pool type sizet_vector vm_heap
 
-CFLAGS ?= -Wxla
+CFLAGS ?= -Wxla -Otime
 
 INSTDIR ?= <Obey$Dir>
 

--- a/frontend/ROMakefile
+++ b/frontend/ROMakefile
@@ -5,7 +5,7 @@ COMPONENT = frontend
 OBJS = builtins_ir basic_keywords call expression globals hash_table parser symbol_table symbol_table_test variable type_if float64_type int32_type array_float64_type array_int32_type array_string_type array_type parser_array parser_assignment parser_call parser_compound parser_cond parser_exp parser_math parser_error parser_graphics parser_input parser_loops parser_output parser_os parser_mem parser_string parser_rnd string_type_if string_type reference_type local_buffer_type
 
 
-CFLAGS ?= -Wxla
+CFLAGS ?= -Wxla -Otime
 
 INSTDIR ?= <Obey$Dir>
 


### PR DESCRIPTION
We're now compiling with -Otime.  This increases the binary size by
5Kb but hopefully speeds up the compiler a bit.

Signed-off-by: Mark Ryan <markusdryan@gmail.com>