### PR TITLE
Fix some warnings reported by gcc-10

### DIFF
--- a/arch/arm32/arm_encode.c
+++ b/arch/arm32/arm_encode.c
@@ -2190,8 +2190,8 @@ static void prv_encode_directive(void *user_data, subtilis_arm_op_t *op,
 		prv_ensure_code_size(ud, 4, err);
 		if (err->type != SUBTILIS_ERROR_OK)
 			return;
-		*((uint32_t *)&ud->code[ud->bytes_written]) =
-		    *((uint32_t *)&op->op.flt);
+		dbl_ptr = (uint32_t *)&op->op.flt;
+		*((uint32_t *)&ud->code[ud->bytes_written]) = *dbl_ptr;
 		ud->bytes_written += 4;
 		break;
 	case SUBTILIS_ARM_OP_STRING:

--- a/arch/arm32/assembler.c
+++ b/arch/arm32/assembler.c
@@ -2409,8 +2409,8 @@ static void prv_parse_vfp_sysreg(subtilis_arm_ass_context_t *c,
 				 subtilis_arm_ccode_type_t ccode,
 				 subtilis_error_t *err)
 {
-	subtilis_arm_reg_t sysreg;
-	subtilis_arm_reg_t reg;
+	subtilis_arm_reg_t sysreg = SIZE_MAX;
+	subtilis_arm_reg_t reg = SIZE_MAX;
 	const char *tbuf;
 
 	if (!strcmp(name, "FMSTAT")) {


### PR DESCRIPTION
In the assembler and the encoder.

Signed-off-by: Mark Ryan <markusdryan@gmail.com>