### PR TITLE
Fix the RO build

### DIFF
--- a/Mk,fd7
+++ b/Mk,fd7
@@ -5,6 +5,8 @@ Dir <Obey$Dir>.frontend
 amu -f ROMakefile THROWBACK=-throwback
 Dir <Obey$Dir>.arch.arm32
 amu -f ROMakefile THROWBACK=-throwback
+Dir <Obey$Dir>.backends.riscos_common
+amu -f ROMakefile THROWBACK=-throwback
 Dir <Obey$Dir>.backends.riscos
 amu -f ROMakefile THROWBACK=-throwback
 Dir <Obey$Dir>

--- a/MkClean,fd7
+++ b/MkClean,fd7
@@ -5,6 +5,8 @@ Dir <Obey$Dir>.frontend
 amu -f ROMakefile clean
 Dir <Obey$Dir>.arch.arm32
 amu -f ROMakefile clean
+Dir <Obey$Dir>.backends.riscos_common
+amu -f ROMakefile clean
 Dir <Obey$Dir>.backends.riscos
 amu -f ROMakefile clean
 Dir <Obey$Dir>

--- a/ROMakefile
+++ b/ROMakefile
@@ -3,7 +3,7 @@
 COMPONENT = subtro
 
 OBJS = subtro
-LIBS = backends.riscos.o.riscos_arm2 backends.riscos_common.o.riscos_common arch.arm32.o.arm32 frontend.o.frontend common.o.common
+LIBS = backends.riscos.o.riscos backends.riscos_common.o.riscos_common arch.arm32.o.arm32 frontend.o.frontend common.o.common
 
 CFLAGS ?= -Wxla -Otime
 

--- a/arch/arm32/ROMakefile
+++ b/arch/arm32/ROMakefile
@@ -2,7 +2,7 @@
 
 COMPONENT = arm32
 
-OBJS = arm2_div arm_core arm_dump arm_encode arm_fpa_dist arm_gen arm_keywords arm_int_dist arm_link arm_peephole arm_reg_alloc arm_sub_section arm_vm arm_walker fpa fpa_alloc fpa_gen arm_mem arm_heap assembler arm_expression vfp
+OBJS = arm2_div arm_core arm_dump arm_encode arm_fpa_dist arm_gen arm_keywords arm_int_dist arm_link arm_peephole arm_reg_alloc arm_sub_section arm_walker fpa fpa_alloc fpa_gen arm_mem arm_heap assembler arm_expression vfp
 
 CFLAGS ?= -Wxla -Otime
 

--- a/backends/riscos/ROMakefile
+++ b/backends/riscos/ROMakefile
@@ -1,6 +1,6 @@
 # Makefile for basicc
 
-COMPONENT = riscos_arm2
+COMPONENT = riscos
 
 OBJS = riscos_arm2 riscos_swi
 


### PR DESCRIPTION
It doesn't seem to like it when a library and an C file have the same name.
Also, we'd forgotten to add the new library, riscos_common, to the Mk
file.  Finally, arm_vm.c was being included in the compiler for some reason.

Signed-off-by: Mark Ryan <markusdryan@gmail.com>