### PR TITLE
Assembler: Add support for MSR and MRS

### DIFF
--- a/arch/arm32/arm_core.c
+++ b/arch/arm32/arm_core.c
@@ -1628,7 +1628,6 @@ void subtilis_arm_add_flags(subtilis_arm_section_t *s,
 
 	flags = &instr->operands.flags;
 	flags->ccode = ccode;
-	flags = &instr->operands.flags;
 	flags->flag_reg = flag_reg;
 	flags->fields = fields;
 	flags->op2_reg = true;

--- a/arch/arm32/arm_disass.c
+++ b/arch/arm32/arm_disass.c
@@ -205,16 +205,16 @@ static void prv_decode_msr(subtilis_arm_instr_t *instr, uint32_t encoded,
 	subtilis_arm_flags_instr_t *flags = &instr->operands.flags;
 
 	instr->type = SUBTILIS_ARM_INSTR_MSR;
-	flags->fields = (encoded >> 16) & 0xf;
+	flags->fields = encoded & (0xf << 16);
 	flags->ccode = encoded >> 28;
 	flags->flag_reg = (encoded & (1 << 22)) ? SUBTILIS_ARM_FLAGS_SPSR
 						: SUBTILIS_ARM_FLAGS_CPSR;
-	if ((encoded & 1 << 25)) {
+	if (encoded & (1 << 25)) {
 		flags->op.integer = encoded & 0xfff;
 		flags->op2_reg = false;
 	} else {
 		flags->op2_reg = true;
-		flags->op.reg = (encoded >> 12) & 0xf;
+		flags->op.reg = encoded & 0xf;
 	}
 }
 

--- a/arch/arm32/arm_encode.c
+++ b/arch/arm32/arm_encode.c
@@ -1040,13 +1040,13 @@ static void prv_encode_flags_instr(void *user_data, subtilis_arm_op_t *op,
 		word |= (instr->op.reg & 0xf) << 12;
 	} else {
 		word = 0x01200000;
-		if (instr->flag_reg) {
+		if (instr->op2_reg) {
 			word |= instr->op.reg & 0xf;
 		} else {
 			word |= 1 << 25;
 			word |= (instr->op.integer & 0xfff);
 		}
-		word |= (instr->fields & 0xf) << 16;
+		word |= instr->fields;
 	}
 
 	if (instr->flag_reg == SUBTILIS_ARM_FLAGS_SPSR)

--- a/arch/arm32/arm_expression.h
+++ b/arch/arm32/arm_expression.h
@@ -26,11 +26,24 @@ typedef enum {
 	SUBTILIS_ARM_EXP_TYPE_SREG,
 	SUBTILIS_ARM_EXP_TYPE_DREG,
 	SUBTILIS_ARM_EXP_TYPE_SYSREG,
+	SUBTILIS_ARM_EXP_TYPE_FLAGS_REG,
 	SUBTILIS_ARM_EXP_TYPE_INT,
 	SUBTILIS_ARM_EXP_TYPE_REAL,
 	SUBTILIS_ARM_EXP_TYPE_STRING,
 	SUBTILIS_ARM_EXP_TYPE_ID,
 } subtilis_arm_exp_type_t;
+
+/* clang-format off */
+enum {
+	SUBTILIS_ARM_EXP_CPSR_REG,
+	SUBTILIS_ARM_EXP_SPSR_REG,
+	SUBTILIS_ARM_EXP_CONTROL_REG = SUBTILIS_ARM_FLAGS_FIELD_CONTROL,
+	SUBTILIS_ARM_EXP_EXT_REG = SUBTILIS_ARM_FLAGS_FIELD_EXTENSION,
+	SUBTILIS_ARM_EXP_STATUS_REG = SUBTILIS_ARM_FLAGS_FIELD_STATUS,
+	SUBTILIS_ARM_EXP_FLAGS_REG = SUBTILIS_ARM_FLAGS_FIELD_FLAGS,
+};
+
+/* clang-format on */
 
 struct subtilis_arm_exp_val_t_ {
 	subtilis_arm_exp_type_t type;
@@ -60,6 +73,9 @@ subtilis_arm_reg_t subtilis_arm_exp_parse_dreg(subtilis_arm_ass_context_t *c,
 					       subtilis_error_t *err);
 subtilis_arm_reg_t subtilis_arm_exp_parse_sysreg(subtilis_arm_ass_context_t *c,
 						 const char *id);
+subtilis_arm_reg_t
+subtilis_arm_exp_parse_flagsreg(subtilis_arm_ass_context_t *c, const char *id);
+
 subtilis_arm_exp_val_t *subtilis_arm_exp_pri7(subtilis_arm_ass_context_t *c,
 					      subtilis_error_t *err);
 subtilis_arm_exp_val_t *subtilis_arm_exp_val_get(subtilis_arm_ass_context_t *c,
@@ -82,6 +98,8 @@ subtilis_arm_exp_val_t *subtilis_arm_exp_new_sreg(subtilis_arm_reg_t reg,
 						  subtilis_error_t *err);
 subtilis_arm_exp_val_t *subtilis_arm_exp_new_sysreg(subtilis_arm_reg_t reg,
 						    subtilis_error_t *err);
+subtilis_arm_exp_val_t *subtilis_arm_exp_new_flagsreg(subtilis_arm_reg_t reg,
+						      subtilis_error_t *err);
 subtilis_arm_exp_val_t *subtilis_arm_exp_new_id(const char *id,
 						subtilis_error_t *err);
 subtilis_arm_exp_val_t *subtilis_arm_exp_dup(subtilis_arm_exp_val_t *val,

--- a/backends/ptd/ptd_test.c
+++ b/backends/ptd/ptd_test.c
@@ -818,6 +818,24 @@ static const subtilis_test_case_t riscos_vfp_test_cases[] = {
 	"80011111\n81811111\n80011111\nEEEF7777\nEFEF7777\nEEEF8888\n"
 	"2000FFFF\n2020FFFF\nFFFF3001\n70000000\n70700000\n3001FFFF\n"
 	},
+	{"msr_mrs",
+	"print ~FNMSR%\n"
+	"print ~FNMSR2%\n"
+	"def FNMSR%\n"
+	"[\n"
+	"MSR CPSR_cxsf, &ff << 28\n"
+	"MRS R0, CPSR\n"
+	"MOV PC, R14\n"
+	"]\n"
+	"def FNMSR2%\n"
+	"[\n"
+	"MOV R1, &ff << 28\n"
+	"MSR CPSR_cxsf, R1\n"
+	"MRS R0, CPSR\n"
+	"MOV PC, R14\n"
+	"]\n",
+	"F0000000\nF0000000\n"
+	},
 };
 
 /* clang-format on */

--- a/backends/riscos/arm_test.c
+++ b/backends/riscos/arm_test.c
@@ -941,6 +941,26 @@ static const subtilis_bad_test_case_t riscos_arm_bad_test_cases[] = {
 	 "def PROCBadLDRS [ LDRD R1, [R1] ]\n",
 	 SUBTILIS_ERROR_ASS_BAD_REG,
 	},
+	{"assembler_msr_no_flags",
+	 "def PROCBadMSR [ MSR CPSR, R0 ]\n",
+	 SUBTILIS_ERROR_EXPECTED,
+	},
+	{"assembler_msr_id",
+	 "def PROCBadMSR [ MSR CPSR_, R0 ]\n",
+	 SUBTILIS_ERROR_EXPECTED,
+	},
+	{"assembler_msr_double_flags",
+	 "def PROCBadMSR [ MSR CPSR_cc, R0 ]\n",
+	 SUBTILIS_ERROR_EXPECTED,
+	},
+	{"assembler_msr_unknown_flags",
+	 "def PROCBadMSR [ MSR CPSR_ab, R0 ]\n",
+	 SUBTILIS_ERROR_EXPECTED,
+	},
+	{"assembler_msr_too_many_flags",
+	 "def PROCBadMSR [ MSR CPSR_cfsxs, R0 ]\n",
+	 SUBTILIS_ERROR_EXPECTED,
+	}
 };
 
 /* clang-format on */


### PR DESCRIPTION
MSR and MRS are now supported by the assembler.  They were previously
used by the compiler but never exposed by the assembler.  A bug in
the encoding of MSR was also fixed.

Signed-off-by: Mark Ryan <markusdryan@gmail.com>