### PR TITLE
README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # Subtilis
 
-[![Build Status](https://travis-ci.org/markdryan/subtilis.svg?branch=master)](https://travis-ci.org/markdryan/subtilis)
-
-
-A BASIC compiler for retro computers.
+A BASIC-like compiler for retro computers.
 
 BASIC is over 50 years old and may not be the most respected of computer
 languages, but it, at least the BBC variant of BASIC, is not that bad really.


### PR DESCRIPTION
Refer to Subtilis as a BASIC-like compiler and remove the Travis
build banner, as we don't build with travis anymore.

Signed-off-by: Mark Ryan <markusdryan@gmail.com>